### PR TITLE
BUG: remove Paul Moore as the main contact info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 The Stubby UEFI Bootloader
 ===============================================================================
-Contact: pmoore2@cisco.com or paul@paul-moore.com
 
 The stubby bootloader is a simple UEFI stub that can be combined with a Linux
 Kernel, initrd, and kernel command line to create a single UEFI application

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,7 +18,6 @@ is made public, but we will make every effort to address the issue as quickly
 as possible and shorten the disclosure window.
 
 * Serge Hallyn, serge@hallyn.com
-* Paul Moore, paul@paul-moore.com
 
 ### Resolving Sensitive Security Issues
 


### PR DESCRIPTION
As my Cisco email is no longer valid and I'm not actively working
with this project, it seems wrong to keep my name as a main point of
contact.

Signed-off-by: Paul Moore <paul@paul-moore.com>