### PR TITLE
Feature/check cmdline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,3 +18,6 @@ jobs:
       - name: Build
         run: |
           make build
+      - name: Unit Test
+        run: |
+          make test

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.o
 *.so
 *.efi
+test-cmdline

--- a/Makefile
+++ b/Makefile
@@ -30,10 +30,10 @@ STUBBY_OBJS = \
 	kcmdline.o \
 
 .PHONY: all
-all: build
+all: build test
 
 .PHONY: build
-build: stubby.efi
+build: stubby.efi test-cmdline
 
 stubby.so: ${STUBBY_OBJS}
 	${LD} ${LDFLAGS} $^ -o $@ -lefi -lgnuefi
@@ -42,6 +42,18 @@ stubby.so: ${STUBBY_OBJS}
 	objcopy -j .text -j .sdata -j .data -j .dynamic \
 		-j .dynsym  -j .rel -j .rela -j .reloc \
 		--target=efi-app-${ARCH} $^ $@
+
+
+.PHONY: test
+test: test-cmdline
+	./test-cmdline
+
+LINUX_TEST_CFLAGS := -DLINUX_TEST $(filter-out -fshort-wchar,$(CFLAGS))
+%-lt.o: %.c
+	$(CC) $(LINUX_TEST_CFLAGS) -c -o $@ $^
+
+test-cmdline: linux_efilib-lt.o kcmdline-lt.o test-cmdline-lt.o
+	$(CC) $(LINUX_TEST_CFLAGS) -o $@ $^
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ STUBBY_OBJS = \
 	pe.o \
 	linux.o \
 	stub.o \
+	kcmdline.o \
 
 .PHONY: all
 all: build

--- a/kcmdline.c
+++ b/kcmdline.c
@@ -48,12 +48,14 @@ EFI_STATUS check_cmdline(CONST CHAR8 *cmdline, UINTN cmdline_len) {
 	CHAR8 c = '\0';
 	CHAR8 *buf = NULL;
 	CHAR8 *tokens[MAX_TOKENS];
+	EFI_STATUS status = EFI_SUCCESS;
 	int i;
 	int start = -1;
 	int num_toks = 0;
 	buf = AllocatePool(cmdline_len);
-	if (!buf)
+	if (!buf) {
 		return EFI_OUT_OF_RESOURCES;
+	}
 
 	CopyMem(buf, cmdline, cmdline_len);
 
@@ -62,11 +64,13 @@ EFI_STATUS check_cmdline(CONST CHAR8 *cmdline, UINTN cmdline_len) {
 		c = buf[i];
 		if (c < 0x20 || c > 0x7e) {
 			Print(L"Bad character 0x%02hhx.", buf);
-			return EFI_SECURITY_VIOLATION;
+			status = EFI_SECURITY_VIOLATION;
+			goto out;
 		}
 		if (i >= MAX_TOKENS) {
 			Print(L"Too many tokens in cmdline.");
-			return EFI_SECURITY_VIOLATION;
+			status = EFI_SECURITY_VIOLATION;
+			goto out;
 		}
 
 		if (c == ' ') {
@@ -95,5 +99,8 @@ EFI_STATUS check_cmdline(CONST CHAR8 *cmdline, UINTN cmdline_len) {
 		}
 	}
 
-	return EFI_SUCCESS;
+out:
+
+	FreePool(buf);
+	return status;
 }

--- a/kcmdline.c
+++ b/kcmdline.c
@@ -52,12 +52,14 @@ EFI_STATUS check_cmdline(CONST CHAR8 *cmdline, UINTN cmdline_len) {
 	int i;
 	int start = -1;
 	int num_toks = 0;
-	buf = AllocatePool(cmdline_len);
+	buf = AllocatePool(cmdline_len + 1);
 	if (!buf) {
 		return EFI_OUT_OF_RESOURCES;
 	}
 
 	CopyMem(buf, cmdline, cmdline_len);
+	// make sure it is null terminated.
+	buf[cmdline_len] = '\0';
 
 	// walk buf, populating tokens
 	for (i = 0; i < cmdline_len; i++) {

--- a/kcmdline.c
+++ b/kcmdline.c
@@ -1,0 +1,99 @@
+#include "kcmdline.h"
+#ifdef LINUX_TEST
+#include "linux_efilib.h"
+#else
+#include <efilib.h>
+#endif
+
+// If a provided command line has more tokens (words) than MAX_TOKENS
+// then an error will be returned.
+#define MAX_TOKENS 128
+
+// These are the tokens that are allowed to be passed on EFI cmdline.
+static const CHAR8 allowed[][32] = {
+	"^console=",
+	"^root=oci:",
+	"root=atomix",
+	"ro",
+	"quiet",
+	"verbose",
+	"crashkernel=256M",
+};
+
+
+BOOLEAN is_allowed(const CHAR8 *input) {
+	int len = 0;
+	int input_len = strlena(input);
+	const CHAR8 * token;
+	int num_allowed = sizeof(allowed) / sizeof(allowed[0]);
+	for (int i=0; i<num_allowed; i++) {
+		token = allowed[i];
+		len = strlena(token);
+		if (token[0] == '^') {
+			len = len - 1;
+			token = &token[1];
+		} else if (input_len != len) {
+			continue;
+		}
+		if (strncmpa(token, input, len) == 0) {
+			return TRUE;
+		}
+	}
+	return FALSE;
+}
+
+// check cmdline to make sure it contains only allowed words.
+// return EFI_SUCCESS on safe, EFI_SECURITY_VIOLATION on unsafe;
+EFI_STATUS check_cmdline(CONST CHAR8 *cmdline, UINTN cmdline_len) {
+	CHAR8 c = '\0';
+	CHAR8 *buf = NULL;
+	CHAR8 *tokens[MAX_TOKENS];
+	int i;
+	int start = -1;
+	int num_toks = 0;
+	buf = AllocatePool(cmdline_len);
+	if (!buf)
+		return EFI_OUT_OF_RESOURCES;
+
+	CopyMem(buf, cmdline, cmdline_len);
+
+	// walk buf, populating tokens
+	for (i = 0; i < cmdline_len; i++) {
+		c = buf[i];
+		if (c < 0x20 || c > 0x7e) {
+			Print(L"Bad character 0x%02hhx.", buf);
+			return EFI_SECURITY_VIOLATION;
+		}
+		if (i >= MAX_TOKENS) {
+			Print(L"Too many tokens in cmdline.");
+			return EFI_SECURITY_VIOLATION;
+		}
+
+		if (c == ' ') {
+			// end of a token
+			buf[i] = '\0';
+			if (start >= 0) {
+				tokens[num_toks] = &buf[start];
+				start = -1;
+				num_toks++;
+			}
+		} else {
+			if (start < 0) {
+				start = i;
+			}
+		}
+	}
+	if (start >= 0) {
+		tokens[num_toks] = &buf[start];
+		num_toks++;
+	}
+
+	for (i=0; i < num_toks; i++) {
+		if (!is_allowed(tokens[i])) {
+			Print(L"token not allowed: %s", tokens[i]);
+			return EFI_SECURITY_VIOLATION;
+		}
+	}
+
+	return EFI_SUCCESS;
+}

--- a/kcmdline.h
+++ b/kcmdline.h
@@ -1,0 +1,7 @@
+#ifndef __STUBBY_CMDLINE_H
+#define __STUBBY_CMDLINE_H
+
+#include <efi.h>
+
+EFI_STATUS check_cmdline(CONST CHAR8 *cmdline, UINTN cmdline_len);
+#endif

--- a/linux_efilib.c
+++ b/linux_efilib.c
@@ -1,0 +1,38 @@
+#include "efi.h"
+
+#ifndef LINUX_TEST
+#include "efilib.h"
+#else
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdarg.h>
+#include <wchar.h>
+
+UINTN Print(IN CONST wchar_t *fmt, ...) {
+	int x;
+	va_list args;
+	va_start(args, fmt);
+	x = vwprintf(fmt, args);
+	va_end(args);
+	wprintf(L"\n");
+	return x;
+}
+
+VOID CopyMem(IN VOID *Dest, IN CONST VOID *Src, IN UINTN len) {
+	memcpy(Dest, Src, len);
+}
+
+VOID * AllocatePool(UINTN Size) {
+	return malloc(Size);
+}
+
+UINTN strncmpa(IN CONST CHAR8 *s1, IN CONST CHAR8 *s2, IN UINTN len) {
+	return strncmp((char*)s1, (char*)s2, len);
+}
+
+UINTN strlena(IN CONST CHAR8 *s1) {
+	return strlen((char*)s1);
+}
+#endif
+

--- a/linux_efilib.c
+++ b/linux_efilib.c
@@ -27,6 +27,10 @@ VOID * AllocatePool(UINTN Size) {
 	return malloc(Size);
 }
 
+VOID FreePool (IN VOID *p) {
+	return free(p);
+}
+
 UINTN strncmpa(IN CONST CHAR8 *s1, IN CONST CHAR8 *s2, IN UINTN len) {
 	return strncmp((char*)s1, (char*)s2, len);
 }

--- a/linux_efilib.h
+++ b/linux_efilib.h
@@ -6,6 +6,7 @@
 UINTN  Print(IN CONST wchar_t *fmt, ...);
 VOID   CopyMem(IN VOID *Dest, IN CONST VOID *Src, IN UINTN len);
 VOID * AllocatePool(UINTN Size);
+VOID   FreePool (IN VOID *p);
 UINTN  strncmpa(IN CONST CHAR8 *s1, IN CONST CHAR8 *s2, IN UINTN len);
 UINTN  strlena(IN CONST CHAR8 *s1);
 #endif

--- a/linux_efilib.h
+++ b/linux_efilib.h
@@ -1,0 +1,11 @@
+#ifndef __STUBBY_LINUX_EFILIB_H
+#define __STUBBY_LINUX_EFILIB_H
+
+#include <efi.h>
+#include <wchar.h>
+UINTN  Print(IN CONST wchar_t *fmt, ...);
+VOID   CopyMem(IN VOID *Dest, IN CONST VOID *Src, IN UINTN len);
+VOID * AllocatePool(UINTN Size);
+UINTN  strncmpa(IN CONST CHAR8 *s1, IN CONST CHAR8 *s2, IN UINTN len);
+UINTN  strlena(IN CONST CHAR8 *s1);
+#endif

--- a/stub.c
+++ b/stub.c
@@ -29,6 +29,7 @@
 #include <efilib.h>
 
 #include "disk.h"
+#include "kcmdline.h"
 #include "linux.h"
 #include "pe.h"
 #include "util.h"
@@ -120,6 +121,16 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table)
 		for (i = 0; i < cmdline_len; i++)
 			line[i] = options[i];
 		cmdline = line;
+
+		err = check_cmdline(cmdline, cmdline_len);
+		if (EFI_ERROR(err)) {
+			if (secure) {
+				Print(L"Custom kernel command line rejected");
+				return err;
+			} else {
+				Print(L"Custom kernel would be rejected in secure mode");
+			}
+		}
 	}
 
 	/* export the device path we are started from, if it's not set yet */

--- a/test-cmdline.c
+++ b/test-cmdline.c
@@ -1,0 +1,79 @@
+#include "kcmdline.h"
+#include "linux_efilib.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+EFI_STATUS do_check_cmdline(const char* cmdline) {
+   return check_cmdline((unsigned char*)cmdline, strlen(cmdline));
+}
+
+typedef struct {
+	EFI_STATUS expected;
+	char cmdline[128];
+} TestData;
+
+
+TestData tests[] = {
+	{EFI_SUCCESS, "console=ttyS0"},
+	{EFI_SUCCESS, ""},
+	{EFI_SUCCESS, "   "},
+	{EFI_SUCCESS, "quiet"},
+	{EFI_SUCCESS, " root=atomix console=ttyS0"},
+	{EFI_SUCCESS, " root=atomix console=/dev/ttyS0 "},
+	{EFI_SUCCESS, "root=atomix console=/dev/ttyS0"},
+	{EFI_SECURITY_VIOLATION, "root=atomix init=/bin/bash debug"},
+	{EFI_SECURITY_VIOLATION, "init=/bin/bash"},
+	{EFI_SECURITY_VIOLATION, "root=\tatomix"},
+	// 'quiet' is allowed, but 'quieter' should not be.
+	{EFI_SECURITY_VIOLATION, "quieter"},
+};
+
+
+char* efiStatusStr(const EFI_STATUS n) {
+	if (n == EFI_SUCCESS)
+		return "allow";
+	if (n == EFI_SECURITY_VIOLATION)
+		return "reject-S";
+	if (n == EFI_OUT_OF_RESOURCES)
+		return "reject-R";
+	wprintf(L"FAIL: unknown number: '%ld'\n", n);
+	exit(1);
+}
+
+int main()
+{
+	EFI_STATUS ret;
+	TestData td;
+	int fails = 0;
+	int passes = 0;
+	int num = sizeof(tests) / sizeof(tests[0]);
+	char nbuf[3];
+	wchar_t *fmt = L"%02s | %-4s | %-8s | %-8s |%s|\n";
+
+	wprintf(fmt, "#", "rslt", "expect", "found", "cmdline");
+	for (int i=0; i<num; i++) {
+		td = tests[i];
+		ret = do_check_cmdline(td.cmdline);
+		sprintf(nbuf, "%02d", i+1);
+		if (ret == td.expected) {
+			wprintf(fmt, nbuf, "PASS",
+					efiStatusStr(td.expected), efiStatusStr(ret),
+					td.cmdline);
+			passes++;
+		} else {
+			wprintf(fmt, nbuf, "FAIL",
+					efiStatusStr(td.expected), efiStatusStr(ret),
+					td.cmdline);
+			fails++;
+		}
+	}
+
+	wprintf(L"passed: %d. failed: %d\n", passes, fails);
+	if (fails != 0) {
+		return 1;
+	}
+
+	return 0;
+}


### PR DESCRIPTION
The point of this PR is to add an "allowed list" to kernel command line processing.
The changes implement the following and add some sort of unit test just to  make things easier to develop.

If there is no built-in kernel command line, then check that the
provided command line contains only allowed tokens.

If booted in secure mode and an invalid token is found, then
the loader will exit failure.  If booted in insecure mode, then
the loader will print a warning and continue.

Token checks are against a static list of words (allowed).
Words in the allowed list beginning with a '^' will be considered
allowed if the input token begins with the word.

For example, '^console=t' will match:

    console=ttyS0
    console=tty0

But will not match:

    console
    console=/dev/ttyS0

The allowed word 'console=ttyS0' will *only* match the exact
string, and will not match console=ttyS0,115200.