### PR TITLE
Small-ish fixes and cleanups.

### DIFF
--- a/kcmdline.c
+++ b/kcmdline.c
@@ -65,12 +65,12 @@ EFI_STATUS check_cmdline(CONST CHAR8 *cmdline, UINTN cmdline_len) {
 	for (i = 0; i < cmdline_len; i++) {
 		c = buf[i];
 		if (c < 0x20 || c > 0x7e) {
-			Print(L"Bad character 0x%02hhx.", buf);
+			Print(L"Bad character 0x%02hhx.\n", buf);
 			status = EFI_SECURITY_VIOLATION;
 			goto out;
 		}
 		if (i >= MAX_TOKENS) {
-			Print(L"Too many tokens in cmdline.");
+			Print(L"Too many tokens in cmdline.\n");
 			status = EFI_SECURITY_VIOLATION;
 			goto out;
 		}
@@ -96,7 +96,7 @@ EFI_STATUS check_cmdline(CONST CHAR8 *cmdline, UINTN cmdline_len) {
 
 	for (i=0; i < num_toks; i++) {
 		if (!is_allowed(tokens[i])) {
-			Print(L"token not allowed: %s", tokens[i]);
+			Print(L"token not allowed: %s\n", tokens[i]);
 			return EFI_SECURITY_VIOLATION;
 		}
 	}

--- a/linux_efilib.c
+++ b/linux_efilib.c
@@ -15,7 +15,6 @@ UINTN Print(IN CONST wchar_t *fmt, ...) {
 	va_start(args, fmt);
 	x = vwprintf(fmt, args);
 	va_end(args);
-	wprintf(L"\n");
 	return x;
 }
 

--- a/stub.c
+++ b/stub.c
@@ -81,7 +81,7 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table)
 				(VOID **)&loaded_image,
 				image, NULL, EFI_OPEN_PROTOCOL_GET_PROTOCOL);
 	if (EFI_ERROR(err)) {
-		Print(L"Error getting a LoadedImageProtocol handle: %r ", err);
+		Print(L"Error getting a LoadedImageProtocol handle: %r\n", err);
 		uefi_call_wrapper(BS->Stall, 1, 3 * 1000 * 1000);
 		return err;
 	}
@@ -94,7 +94,7 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table)
 	err = pe_memory_locate_sections(loaded_image->ImageBase,
 					sections, addrs, offs, szs);
 	if (EFI_ERROR(err)) {
-		Print(L"Unable to locate embedded .linux section: %r ", err);
+		Print(L"Unable to locate embedded .linux section: %r\n", err);
 		uefi_call_wrapper(BS->Stall, 1, 3 * 1000 * 1000);
 		return err;
 	}
@@ -125,10 +125,10 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table)
 		err = check_cmdline(cmdline, cmdline_len);
 		if (EFI_ERROR(err)) {
 			if (secure) {
-				Print(L"Custom kernel command line rejected");
+				Print(L"Custom kernel command line rejected\n");
 				return err;
 			} else {
-				Print(L"Custom kernel would be rejected in secure mode");
+				Print(L"Custom kernel would be rejected in secure mode\n");
 			}
 		}
 	}
@@ -155,7 +155,7 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table)
 			   NULL) != EFI_SUCCESS) {
 		_cleanup_freepool_ CHAR16 *s;
 
-		s = PoolPrint(L"%s %d.%02d",
+		s = PoolPrint(L"%s %d.%02d\n",
 			      ST->FirmwareVendor,
 			      ST->FirmwareRevision >> 16,
 			      ST->FirmwareRevision & 0xffff);
@@ -167,7 +167,7 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table)
 			   NULL) != EFI_SUCCESS) {
 		_cleanup_freepool_ CHAR16 *s;
 
-		s = PoolPrint(L"UEFI %d.%02d", ST->Hdr.Revision >> 16,
+		s = PoolPrint(L"UEFI %d.%02d\n", ST->Hdr.Revision >> 16,
 			      ST->Hdr.Revision & 0xffff);
 		efivar_set(L"LoaderFirmwareType", s, FALSE);
 	}

--- a/stubby-smash.2.sh
+++ b/stubby-smash.2.sh
@@ -95,6 +95,7 @@ assert_file "$arg_cmdline" "cmdline argument"
 assert_file "$arg_sbat" "sbat argument"
 
 # output check
+[ -n "$arg_output" ] || error "Must provide output option (-o FILE.efi)"
 [ ! -e "$arg_output" ] ||
 	error "output file '$arg_output' already exists"
 

--- a/util.c
+++ b/util.c
@@ -405,7 +405,7 @@ EFI_STATUS file_read(EFI_FILE_HANDLE dir, const CHAR16 *name, UINTN off,
 
 EFI_STATUS log_oom(void)
 {
-	Print(L"Out of memory.");
+	Print(L"Out of memory.\n");
 	(void) uefi_call_wrapper(BS->Stall, 1, 3 * 1000 * 1000);
 	return EFI_OUT_OF_RESOURCES;
 }


### PR DESCRIPTION
3 things here:
 * stubby-smash.2.sh will complain if no '-o' is given.
 * stubby-smash.2.sh will check cmdline argument and strip trailing newlines if present.
 * Add '\n' to Print calls. Print is not the equivalent of Println.
