### PR TITLE
Print related fixes and ignore efi executable name

### DIFF
--- a/kcmdline.c
+++ b/kcmdline.c
@@ -65,7 +65,7 @@ EFI_STATUS check_cmdline(CONST CHAR8 *cmdline, UINTN cmdline_len) {
 	for (i = 0; i < cmdline_len; i++) {
 		c = buf[i];
 		if (c < 0x20 || c > 0x7e) {
-			Print(L"Bad character 0x%02hhx.\n", buf);
+			Print(L"Bad character 0x%02hhx in position %d: %a.\n", c, i, cmdline);
 			status = EFI_SECURITY_VIOLATION;
 			goto out;
 		}
@@ -96,7 +96,7 @@ EFI_STATUS check_cmdline(CONST CHAR8 *cmdline, UINTN cmdline_len) {
 
 	for (i=0; i < num_toks; i++) {
 		if (!is_allowed(tokens[i])) {
-			Print(L"token not allowed: %s\n", tokens[i]);
+			Print(L"token not allowed: %a\n", tokens[i]);
 			return EFI_SECURITY_VIOLATION;
 		}
 	}

--- a/kcmdline.c
+++ b/kcmdline.c
@@ -44,6 +44,7 @@ BOOLEAN is_allowed(const CHAR8 *input) {
 
 // check cmdline to make sure it contains only allowed words.
 // return EFI_SUCCESS on safe, EFI_SECURITY_VIOLATION on unsafe;
+// cmdline_len does not include terminating null.
 EFI_STATUS check_cmdline(CONST CHAR8 *cmdline, UINTN cmdline_len) {
 	CHAR8 c = '\0';
 	CHAR8 *buf = NULL;
@@ -59,7 +60,7 @@ EFI_STATUS check_cmdline(CONST CHAR8 *cmdline, UINTN cmdline_len) {
 
 	CopyMem(buf, cmdline, cmdline_len);
 	// make sure it is null terminated.
-	buf[cmdline_len] = '\0';
+	buf[cmdline_len+1] = '\0';
 
 	// walk buf, populating tokens
 	for (i = 0; i < cmdline_len; i++) {

--- a/util.c
+++ b/util.c
@@ -358,6 +358,20 @@ CHAR8 *strchra(CHAR8 *s, CHAR8 c)
 	return NULL;
 }
 
+UINTN find_arg1_offset(const CHAR8 *opts, UINTN len) {
+	int i = 0;
+	for (i=0; i < len; i++) {
+		if (opts[i] == ' ') {
+			i++;
+			break;
+		}
+		if (opts[i] == '\0') {
+			return i;
+		}
+	}
+	return i;
+}
+
 EFI_STATUS file_read(EFI_FILE_HANDLE dir, const CHAR16 *name, UINTN off,
 		     UINTN size, CHAR8 **ret, UINTN *ret_size)
 {

--- a/util.h
+++ b/util.h
@@ -66,6 +66,8 @@ CHAR8 *strchra(CHAR8 *s, CHAR8 c);
 CHAR16 *stra_to_path(CHAR8 *stra);
 CHAR16 *stra_to_str(CHAR8 *stra);
 
+UINTN find_arg1_offset(const CHAR8 *opts, UINTN len);
+
 EFI_STATUS file_read(EFI_FILE_HANDLE dir, const CHAR16 *name, UINTN off,
 		     UINTN size, CHAR8 **content, UINTN *content_size);
 


### PR DESCRIPTION
When stubby uses a builtin commanad line, the command line presented to the kernel would contain only the arguments (console=ttyS0 root=/dev/sda).

But when reading from the efi LoadOptions, it would contain the executable name (kernel.efi or bootx64.efi) in addition to the any arguments found there.

The string 'kernel.efi' did not look like an allowed argument, so it would be denied.  

We could have just not checked arg0 against the allowed list, but then what happens when someone names their kernel.efi file `init=bin/sh` ?  They could rename the filename without invalidating the signature.  Better to just not provide the kernel with the name of the file.