### PR TITLE
Add support for runtime command lines.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,13 +27,17 @@ STUBBY_OBJS = \
 	pe.o \
 	linux.o \
 	stub.o \
+	stra.o \
 	kcmdline.o \
+
+TEST_EXES = test-cmdline test-get-cmdline
+TEST_OBJS = linux_efilib-lt.o kcmdline-lt.o stra-lt.o
 
 .PHONY: all
 all: build test
 
 .PHONY: build
-build: stubby.efi test-cmdline
+build: stubby.efi $(TEST_EXES)
 
 stubby.so: ${STUBBY_OBJS}
 	${LD} ${LDFLAGS} $^ -o $@ -lefi -lgnuefi
@@ -45,18 +49,18 @@ stubby.so: ${STUBBY_OBJS}
 
 
 .PHONY: test
-test: test-cmdline
-	./test-cmdline
+test: $(TEST_EXES)
+	@for t in $(TEST_EXES); do echo -- $$t --; ./$$t || exit; done
 
 LINUX_TEST_CFLAGS := -DLINUX_TEST $(filter-out -fshort-wchar,$(CFLAGS))
 %-lt.o: %.c
 	$(CC) $(LINUX_TEST_CFLAGS) -c -o $@ $^
 
-test-cmdline: linux_efilib-lt.o kcmdline-lt.o test-cmdline-lt.o
+test-%: test-%-lt.o $(TEST_OBJS)
 	$(CC) $(LINUX_TEST_CFLAGS) -o $@ $^
 
 .PHONY: clean
 clean:
-	${RM} -rf *.efi *.so *.o
+	${RM} -rf *.efi *.so *.o $(TEST_EXES)
 
 # kate: syntax Makefile;

--- a/disk.c
+++ b/disk.c
@@ -25,9 +25,7 @@
  *
  */
 
-#include <efi.h>
-#include <efilib.h>
-
+#include "stubby_efi.h"
 #include "util.h"
 
 EFI_STATUS disk_get_part_uuid(EFI_HANDLE *handle, CHAR16 uuid[static 37])

--- a/kcmdline.c
+++ b/kcmdline.c
@@ -1,9 +1,7 @@
+#include "stubby_efi.h"
 #include "kcmdline.h"
-#ifdef LINUX_TEST
-#include "linux_efilib.h"
-#else
-#include <efilib.h>
-#endif
+#include "stra.h"
+
 
 // If a provided command line has more tokens (words) than MAX_TOKENS
 // then an error will be returned.
@@ -19,7 +17,6 @@ static const CHAR8 allowed[][32] = {
 	"verbose",
 	"crashkernel=256M",
 };
-
 
 BOOLEAN is_allowed(const CHAR8 *input) {
 	int len = 0;
@@ -44,7 +41,7 @@ BOOLEAN is_allowed(const CHAR8 *input) {
 
 // check cmdline to make sure it contains only allowed words.
 // return EFI_SUCCESS on safe, EFI_SECURITY_VIOLATION on unsafe;
-EFI_STATUS check_cmdline(CONST CHAR8 *cmdline, UINTN cmdline_len) {
+EFI_STATUS check_cmdline(CONST CHAR8 *cmdline, UINTN cmdline_len, CHAR16 *errmsg, UINTN errmsg_len) {
 	CHAR8 c = '\0';
 	CHAR8 *buf = NULL;
 	CHAR8 *tokens[MAX_TOKENS];
@@ -53,9 +50,12 @@ EFI_STATUS check_cmdline(CONST CHAR8 *cmdline, UINTN cmdline_len) {
 	int start = -1;
 	int num_toks = 0;
 	buf = AllocatePool(cmdline_len + 1);
-	if (!buf) {
-		return EFI_OUT_OF_RESOURCES;
+	if (buf == NULL) {
+		status = EFI_OUT_OF_RESOURCES;
+		goto out;
 	}
+
+	*errmsg = '\0';
 
 	CopyMem(buf, cmdline, cmdline_len);
 	// make sure it is null terminated.
@@ -65,12 +65,13 @@ EFI_STATUS check_cmdline(CONST CHAR8 *cmdline, UINTN cmdline_len) {
 	for (i = 0; i < cmdline_len; i++) {
 		c = buf[i];
 		if (c < 0x20 || c > 0x7e) {
-			Print(L"Bad character 0x%02hhx in position %d: %a.\n", c, i, cmdline);
+			UnicodeSPrint(errmsg, errmsg_len,
+				L"Bad character 0x%02hhx in position %d: %a.\n", c, i, cmdline);
 			status = EFI_SECURITY_VIOLATION;
 			goto out;
 		}
 		if (i >= MAX_TOKENS) {
-			Print(L"Too many tokens in cmdline.\n");
+			UnicodeSPrint(errmsg, errmsg_len, L"Too many tokens in cmdline.\n");
 			status = EFI_SECURITY_VIOLATION;
 			goto out;
 		}
@@ -96,13 +97,206 @@ EFI_STATUS check_cmdline(CONST CHAR8 *cmdline, UINTN cmdline_len) {
 
 	for (i=0; i < num_toks; i++) {
 		if (!is_allowed(tokens[i])) {
-			Print(L"token not allowed: %a\n", tokens[i]);
-			return EFI_SECURITY_VIOLATION;
+			UnicodeSPrint(errmsg, errmsg_len, L"token not allowed: %a\n", tokens[i]);
+			status = EFI_SECURITY_VIOLATION;
 		}
 	}
 
 out:
 
-	FreePool(buf);
+	if (buf != NULL) {
+		FreePool(buf);
+	}
 	return status;
+}
+
+// produce the combined command line from builtin and runtime portions.
+// string lengths builtin_len and runtime_len should not include the terminating null
+// (as returned by strlen).
+EFI_STATUS get_cmdline(
+		BOOLEAN secure,
+		CONST CHAR8 *builtin, UINTN builtin_len,
+		CONST CHAR8 *runtime, UINTN runtime_len,
+		CHAR8 **cmdline, UINTN *cmdline_len,
+		CHAR16 **errmsg) {
+
+	const CHAR8 *marker = (CHAR8 *)"STUBBY_RT_CLI1";
+	const CHAR8 *namespace = (CHAR8 *)"STUBBY_RT";
+	UINTN marker_len = strlena(marker);
+	CHAR8 *p;
+	CHAR8 *part1 = NULL, *part2 = NULL;
+	UINTN part1_len, part2_len;
+	EFI_STATUS status = EFI_SECURITY_VIOLATION;
+
+	*cmdline = NULL;
+	*cmdline_len = 0;
+
+	CHAR16 *errbuf = NULL;
+	int errbuf_buflen = 255;
+	errbuf = AllocatePool(errbuf_buflen * sizeof(CHAR16));
+	if (errbuf == NULL) {
+		status = EFI_OUT_OF_RESOURCES;
+		goto out;
+	}
+
+	part1 = AllocatePool(builtin_len + 1);
+	if (part1 == NULL) {
+		status = EFI_OUT_OF_RESOURCES;
+		goto out;
+	}
+
+	part2 = AllocatePool(builtin_len + 1);
+	if (part2 == NULL) {
+		status = EFI_OUT_OF_RESOURCES;
+		goto out;
+	}
+
+	*part1 = '\0';
+	*part2 = '\0';
+	*errbuf = '\0';
+	part1_len = 0;
+	part2_len = 0;
+
+	if (builtin_len != 0) {
+		p = strstra(builtin, marker);
+		if (p == NULL) {
+			// there was no marker in builtin cmdline
+			if (secure) {
+				if (runtime_len != 0) {
+					status = EFI_INVALID_PARAMETER;
+					UnicodeSPrint(errbuf, errbuf_buflen,
+							L"runtime arguments cannot be given to non-empty builtin without marker\n");
+					goto out;
+				}
+			} else {
+				// insecure and no marker. act as if marker was at end.
+				CopyMem(part1, builtin, builtin_len);
+				part1_len = builtin_len + 1;
+				*(part1 + part1_len - 1) = ' ';
+				*(part1 + part1_len) = '\0';
+			}
+		} else {
+			// builtin has a marker, check that there is only one.
+			if (strstra(p + marker_len, marker) != NULL) {
+				status = EFI_INVALID_PARAMETER;
+				UnicodeSPrint(errbuf, errbuf_buflen,
+						L"%a appears more than once in builtin cmdline\n", marker);
+				goto out;
+			}
+
+			part1_len = p - builtin;
+			part2_len = builtin_len - marker_len - part1_len;
+			if (!((p == builtin || *(p - 1) == ' ') &&
+					(part2_len == 0 || *(p + marker_len) == ' '))) {
+				status = EFI_INVALID_PARAMETER;
+				UnicodeSPrint(errbuf, errbuf_buflen, L"%a is not a full token\n", marker);
+				goto out;
+			}
+
+			CopyMem(part1, builtin, part1_len);
+			*(part1 + part1_len) = '\0';
+			CopyMem(part2, p + marker_len, part2_len);
+			*(part2 + part2_len) = '\0';
+		}
+	}
+
+	// namespace appeared in the builtin (other than marker)
+	if (strstra(part1, namespace) != NULL || strstra(part2, namespace) != NULL) {
+		status = EFI_INVALID_PARAMETER;
+		UnicodeSPrint(errbuf, errbuf_buflen, L"%a appears in builtin cmdline\n", namespace);
+		goto out;
+	}
+
+	// namespace appears in runtime
+	if (strstra(runtime, namespace) != NULL) {
+		status = EFI_INVALID_PARAMETER;
+		UnicodeSPrint(errbuf, errbuf_buflen, L"%a appears in runtime cmdline\n", namespace);
+		goto out;
+	}
+
+	// Print(L"part1=%a|\npart2=%a|\nruntime=%a|\n", part1, part2, runtime);
+	status = check_cmdline(runtime, runtime_len, errbuf, errbuf_buflen);
+
+	// EFI_SECURITY_VIOLATION is allowed if insecure boot, so continue on.
+	if ((status == EFI_SECURITY_VIOLATION && secure) || EFI_ERROR(status)) {
+		goto out;
+	}
+
+	// At this point, part1 and part2 are set so we can just concatenate part1, runtime, part3
+	UINTN clen = part1_len + runtime_len + part2_len;
+	CHAR8 *cbuf;
+	cbuf = AllocatePool(clen + 1);
+	if (cbuf == NULL) {
+		status = EFI_OUT_OF_RESOURCES;
+		goto out;
+	}
+	CopyMem(cbuf, part1, part1_len);
+	CopyMem(cbuf+part1_len, runtime, runtime_len);
+	CopyMem(cbuf+part1_len+runtime_len, part2, part2_len);
+	cbuf[clen] = '\0';
+	*cmdline = cbuf;
+	*cmdline_len = clen;
+
+out:
+	if (errbuf != NULL && errbuf[0] == '\0') {
+		FreePool(errbuf);
+		errbuf = NULL;
+	}
+
+	if (part1 != NULL)
+		FreePool(part1);
+
+	if (part2 != NULL)
+		FreePool(part2);
+
+	*errmsg = errbuf;
+	return status;
+}
+
+// get_cmdline_with_print:
+//   check the command line
+//   return EFI_SUCCESS if command line can be booted.
+//
+// Note: get_cmdline (called by get_cmdline_with_print) will
+// return EFI_SECURITY_VIOLATION the same for secure and insecure.
+// if insecure, this function changes a EFI_SECURITY_VIOLATION return
+// value to EFI_SUCCESS.
+EFI_STATUS get_cmdline_with_print(
+		BOOLEAN secure,
+		CONST CHAR8 *builtin, UINTN builtin_len,
+		CONST CHAR8 *runtime, UINTN runtime_len,
+		CHAR8 **cmdline, UINTN *cmdline_len) {
+
+	CHAR16 *errmsg = NULL;
+	EFI_STATUS err;
+
+	err = get_cmdline(secure,
+		builtin, builtin_len, runtime, runtime_len,
+		cmdline, cmdline_len, &errmsg);
+
+	if (!EFI_ERROR(err)) {
+		goto out;
+	}
+
+	if (errmsg == NULL) {
+		Print(L"%r\n", err);
+	} else {
+		Print(L"%r: %ls\n", err, errmsg);
+	}
+
+	if (err == EFI_SECURITY_VIOLATION) {
+		if (secure) {
+			Print(L"Custom kernel command line rejected\n");
+		} else {
+			Print(L"Custom kernel would be rejected in secure mode\n");
+			err = EFI_SUCCESS;
+		}
+	}
+
+out:
+	if (errmsg != NULL) {
+		FreePool(errmsg);
+	}
+
+	return err;
 }

--- a/kcmdline.h
+++ b/kcmdline.h
@@ -1,7 +1,21 @@
 #ifndef __STUBBY_CMDLINE_H
 #define __STUBBY_CMDLINE_H
 
-#include <efi.h>
+#include "stubby_efi.h"
 
-EFI_STATUS check_cmdline(CONST CHAR8 *cmdline, UINTN cmdline_len);
+EFI_STATUS check_cmdline(CONST CHAR8 *cmdline, UINTN cmdline_len, CHAR16 *errmsg, UINTN errmsg_len);
+
+EFI_STATUS get_cmdline(
+	BOOLEAN secure,
+	CONST CHAR8 *builtin, UINTN builtin_len,
+	CONST CHAR8 *runtime, UINTN runtime_len,
+	CHAR8 **cmdline, UINTN *cmdline_len,
+	CHAR16 **errmsg);
+
+EFI_STATUS get_cmdline_with_print(
+	BOOLEAN secure,
+	CONST CHAR8 *builtin, UINTN builtin_len,
+	CONST CHAR8 *runtime, UINTN runtime_len,
+	CHAR8 **cmdline, UINTN *cmdline_len);
+
 #endif

--- a/linux.c
+++ b/linux.c
@@ -25,8 +25,7 @@
  *
  */
 
-#include <efi.h>
-#include <efilib.h>
+#include "stubby_efi.h"
 
 #include "linux.h"
 #include "util.h"

--- a/linux_efilib.c
+++ b/linux_efilib.c
@@ -1,24 +1,23 @@
-#include "efi.h"
-
-#ifndef LINUX_TEST
-#include "efilib.h"
-#else
+/* This supplies "linux" implementations of the EFI functions that
+ * stubby uses. It allows us to write tests (test-*.c) and run them in linux.
+ */
+#include "linux_efilib.h"
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
 #include <stdarg.h>
 #include <wchar.h>
 
-UINTN Print(IN CONST wchar_t *fmt, ...) {
+wchar_t* _fixup_fmt(const wchar_t *fmt) {
 	// Efilib's Print and libc wprintf differ on the format specifiers
 	// for wchar_t (wide) and char (ascii) strings:
-	//	 lib-name | wchar spec  | char spec |
-	//	 efilib   | %ls, %s	 | %a		|
-	//	 libc	 | %ls		 | %s		|
+	//   lib-name | wchar spec  | char spec |
+	//   efilib   | %ls, %s     | %a        |
+	//   libc     | %ls         | %s        |
 	//
 	// To simplify things:
-	//  * restrict callers of 'Print' to only '%ls' or '%a'
-	//  * change %a (ascii) to %s before calling vwprintf
+	//  * restrict callers to only '%ls' or '%a'
+	//  * change %a (ascii) to %s
 	if (wcsstr(fmt, L"%s") != NULL) {
 		wprintf(L"ERROR: cannot use '%%s' in fmt string: %ls\n", fmt);
 		exit(1);
@@ -41,6 +40,12 @@ UINTN Print(IN CONST wchar_t *fmt, ...) {
 		last = fmt[i];
 	}
 
+	return fixedfmt;
+}
+
+UINTN Print(IN CONST CHAR16 *fmt, ...) {
+	wchar_t *fixedfmt = _fixup_fmt(fmt);
+
 	int x;
 	va_list args;
 	va_start(args, fmt);
@@ -48,6 +53,20 @@ UINTN Print(IN CONST wchar_t *fmt, ...) {
 	va_end(args);
 
 	free(fixedfmt);
+	return x;
+}
+
+UINTN UnicodeSPrint(OUT CHAR16 *Str, IN UINTN StrSize, IN CONST CHAR16 *fmt, ...) {
+	wchar_t *fixedfmt = _fixup_fmt(fmt);
+
+	int x;
+	va_list args;
+	va_start(args, fmt);
+	x = vswprintf(Str, StrSize, fixedfmt, args);
+	va_end(args);
+
+	free(fixedfmt);
+
 	return x;
 }
 
@@ -70,5 +89,62 @@ UINTN strncmpa(IN CONST CHAR8 *s1, IN CONST CHAR8 *s2, IN UINTN len) {
 UINTN strlena(IN CONST CHAR8 *s1) {
 	return strlen((char*)s1);
 }
-#endif
 
+// from efilib/lib/error.c
+struct {
+    EFI_STATUS      Code;
+    WCHAR	    *Desc;
+} ErrorCodeTable[] = {
+	{  EFI_SUCCESS,                L"Success"},
+	{  EFI_LOAD_ERROR,             L"Load Error"},
+	{  EFI_INVALID_PARAMETER,      L"Invalid Parameter"},
+	{  EFI_UNSUPPORTED,            L"Unsupported"},
+	{  EFI_BAD_BUFFER_SIZE,        L"Bad Buffer Size"},
+	{  EFI_BUFFER_TOO_SMALL,       L"Buffer Too Small"},
+	{  EFI_NOT_READY,              L"Not Ready"},
+	{  EFI_DEVICE_ERROR,           L"Device Error"},
+	{  EFI_WRITE_PROTECTED,        L"Write Protected"},
+	{  EFI_OUT_OF_RESOURCES,       L"Out of Resources"},
+	{  EFI_VOLUME_CORRUPTED,       L"Volume Corrupt"},
+	{  EFI_VOLUME_FULL,            L"Volume Full"},
+	{  EFI_NO_MEDIA,               L"No Media"},
+	{  EFI_MEDIA_CHANGED,          L"Media changed"},
+	{  EFI_NOT_FOUND,              L"Not Found"},
+	{  EFI_ACCESS_DENIED,          L"Access Denied"},
+	{  EFI_NO_RESPONSE,            L"No Response"},
+	{  EFI_NO_MAPPING,             L"No mapping"},
+	{  EFI_TIMEOUT,                L"Time out"},
+	{  EFI_NOT_STARTED,            L"Not started"},
+	{  EFI_ALREADY_STARTED,        L"Already started"},
+	{  EFI_ABORTED,                L"Aborted"},
+	{  EFI_ICMP_ERROR,             L"ICMP Error"},
+	{  EFI_TFTP_ERROR,             L"TFTP Error"},
+	{  EFI_PROTOCOL_ERROR,         L"Protocol Error"},
+	{  EFI_INCOMPATIBLE_VERSION,   L"Incompatible Version"},
+	{  EFI_SECURITY_VIOLATION,     L"Security Policy Violation"},
+	{  EFI_CRC_ERROR,              L"CRC Error"},
+	{  EFI_END_OF_MEDIA,           L"End of Media"},
+	{  EFI_END_OF_FILE,            L"End of File"},
+	{  EFI_INVALID_LANGUAGE,       L"Invalid Languages"},
+	{  EFI_COMPROMISED_DATA,       L"Compromised Data"},
+
+	// warnings
+	{  EFI_WARN_UNKNOWN_GLYPH,     L"Warning Unknown Glyph"},
+	{  EFI_WARN_DELETE_FAILURE,    L"Warning Delete Failure"},
+	{  EFI_WARN_WRITE_FAILURE,     L"Warning Write Failure"},
+	{  EFI_WARN_BUFFER_TOO_SMALL,  L"Warning Buffer Too Small"},
+	{  0, NULL}
+} ;
+
+VOID StatusToString(OUT CHAR16 *Buffer, IN EFI_STATUS Status) {
+    UINTN           Index;
+
+    for (Index = 0; ErrorCodeTable[Index].Desc; Index +=1) {
+        if (ErrorCodeTable[Index].Code == Status) {
+	    wcscpy (Buffer, ErrorCodeTable[Index].Desc);
+            return;
+        }
+    }
+
+    UnicodeSPrint (Buffer, 0, L"%X", Status);
+}

--- a/linux_efilib.h
+++ b/linux_efilib.h
@@ -1,12 +1,99 @@
+/* This supplies the necessary defines for stubby's use of efi. */
 #ifndef __STUBBY_LINUX_EFILIB_H
 #define __STUBBY_LINUX_EFILIB_H
 
-#include <efi.h>
+#include <stdint.h>
 #include <wchar.h>
-UINTN  Print(IN CONST wchar_t *fmt, ...);
+
+typedef uint64_t   UINT64;
+typedef uint32_t   UINT32;
+typedef uint16_t   UINT16;
+typedef uint8_t    UINT8;
+typedef uint64_t   UINTN;
+typedef int64_t    INTN;
+
+// This is the hack if you use this code, then:
+//   sizeof(CHAR16) == 4
+//
+// It allows using the existing code that uses CHAR16
+// with wprintf and friends.
+//
+// For test programs we need a implementations of Print
+// and UnicodeSprint, but don't want to write them.  We use
+// wprintf and friends.  The problem with that is libc expects a
+// wchar_t of 4 bytes, but EFI applications compile with
+// -fshort-wchar which means sizeof(Lthat sizeof(L"foo") == 2.
+typedef wchar_t CHAR16;
+typedef wchar_t WCHAR;
+
+typedef UINT8	CHAR8;
+typedef UINT8           BOOLEAN;
+typedef UINTN           EFI_STATUS;
+
+// this is specific based on what EFI_STATUS is.
+#define EFIERR(a)           (0x8000000000000000 | a)
+#ifndef IN
+    #define IN
+    #define OUT
+    #define OPTIONAL
+#endif
+
+#define CONST const
+#define VOID void
+#define TRUE    ((BOOLEAN) 1)
+#define FALSE   ((BOOLEAN) 0)
+
+// efierr.h
+#define EFIWARN(a)                            (a)
+#define EFI_ERROR(a)              (((INTN) a) < 0)
+
+#define EFI_SUCCESS                             0
+#define EFI_LOAD_ERROR                  EFIERR(1)
+#define EFI_INVALID_PARAMETER           EFIERR(2)
+#define EFI_UNSUPPORTED                 EFIERR(3)
+#define EFI_BAD_BUFFER_SIZE             EFIERR(4)
+#define EFI_BUFFER_TOO_SMALL            EFIERR(5)
+#define EFI_NOT_READY                   EFIERR(6)
+#define EFI_DEVICE_ERROR                EFIERR(7)
+#define EFI_WRITE_PROTECTED             EFIERR(8)
+#define EFI_OUT_OF_RESOURCES            EFIERR(9)
+#define EFI_VOLUME_CORRUPTED            EFIERR(10)
+#define EFI_VOLUME_FULL                 EFIERR(11)
+#define EFI_NO_MEDIA                    EFIERR(12)
+#define EFI_MEDIA_CHANGED               EFIERR(13)
+#define EFI_NOT_FOUND                   EFIERR(14)
+#define EFI_ACCESS_DENIED               EFIERR(15)
+#define EFI_NO_RESPONSE                 EFIERR(16)
+#define EFI_NO_MAPPING                  EFIERR(17)
+#define EFI_TIMEOUT                     EFIERR(18)
+#define EFI_NOT_STARTED                 EFIERR(19)
+#define EFI_ALREADY_STARTED             EFIERR(20)
+#define EFI_ABORTED                     EFIERR(21)
+#define EFI_ICMP_ERROR                  EFIERR(22)
+#define EFI_TFTP_ERROR                  EFIERR(23)
+#define EFI_PROTOCOL_ERROR              EFIERR(24)
+#define EFI_INCOMPATIBLE_VERSION        EFIERR(25)
+#define EFI_SECURITY_VIOLATION          EFIERR(26)
+#define EFI_CRC_ERROR                   EFIERR(27)
+#define EFI_END_OF_MEDIA                EFIERR(28)
+#define EFI_END_OF_FILE                 EFIERR(31)
+#define EFI_INVALID_LANGUAGE            EFIERR(32)
+#define EFI_COMPROMISED_DATA            EFIERR(33)
+
+#define EFI_WARN_UNKOWN_GLYPH           EFIWARN(1)
+#define EFI_WARN_UNKNOWN_GLYPH          EFIWARN(1)
+#define EFI_WARN_DELETE_FAILURE         EFIWARN(2)
+#define EFI_WARN_WRITE_FAILURE          EFIWARN(3)
+#define EFI_WARN_BUFFER_TOO_SMALL       EFIWARN(4)
+
+
+UINTN  Print(IN CONST CHAR16 *fmt, ...);
+UINTN  UnicodeSPrint(OUT CHAR16 *Str, IN UINTN StrSize, IN CONST CHAR16 *fmt, ...);
 VOID   CopyMem(IN VOID *Dest, IN CONST VOID *Src, IN UINTN len);
 VOID * AllocatePool(UINTN Size);
 VOID   FreePool (IN VOID *p);
 UINTN  strncmpa(IN CONST CHAR8 *s1, IN CONST CHAR8 *s2, IN UINTN len);
 UINTN  strlena(IN CONST CHAR8 *s1);
+
+VOID   StatusToString(OUT CHAR16 *Buffer, IN EFI_STATUS Status);
 #endif

--- a/make.conf
+++ b/make.conf
@@ -31,7 +31,7 @@ EFI_CRT_OBJS = ${EFILIB}/crt0-efi-${ARCH}.o
 EFI_LDS = ${EFILIB}/elf_${ARCH}_efi.lds
 
 CFLAGS = \
-        -Wall \
+        -Wall -Werror \
         ${EFIINCS} -fno-stack-protector -fpic -fshort-wchar -mno-red-zone \
         -DGIT_VERSION=\"$(shell git rev-parse HEAD | cut -c1-12)\"
 ifeq (${ARCH},x86_64)

--- a/pe.c
+++ b/pe.c
@@ -25,8 +25,7 @@
  *
  */
 
-#include <efi.h>
-#include <efilib.h>
+#include "stubby_efi.h"
 
 #include "pe.h"
 #include "util.h"

--- a/stra.c
+++ b/stra.c
@@ -1,0 +1,14 @@
+#include "stra.h"
+#include "stubby_efi.h"
+
+// strstr for ascii string
+CHAR8 *strstra(const CHAR8 *input, const CHAR8 *find) {
+	const CHAR8 *p, *q;
+	do {
+		for (p = input, q = find; *q != '\0' && *p == *q; p++, q++) {}
+		if (*q == '\0') {
+			return (CHAR8*)input;
+		}
+	} while (*(input++) != '\0');
+	return NULL;
+}

--- a/stra.h
+++ b/stra.h
@@ -1,0 +1,8 @@
+#ifndef __STUBBY_STRA_H
+#define __STUBBY_STRA_H
+
+#include "stubby_efi.h"
+
+CHAR8 *strstra(const CHAR8 *input, const CHAR8 *find);
+
+#endif

--- a/stub.c
+++ b/stub.c
@@ -25,8 +25,7 @@
  *
  */
 
-#include <efi.h>
-#include <efilib.h>
+#include "stubby_efi.h"
 
 #include "disk.h"
 #include "kcmdline.h"
@@ -69,8 +68,12 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table)
 	UINTN addrs[ELEMENTSOF(sections) - 1] = {};
 	UINTN offs[ELEMENTSOF(sections) - 1] = {};
 	UINTN szs[ELEMENTSOF(sections) - 1] = {};
+	CHAR8 *bt_cmdline = NULL;
+	UINTN bt_cmdline_len = 0;
+	CHAR8 *rt_cmdline = NULL;
+	UINTN rt_cmdline_len = 0;
 	CHAR8 *cmdline = NULL;
-	UINTN cmdline_len;
+	UINTN cmdline_len = 0;
 	CHAR16 uuid[37];
 	EFI_STATUS err;
 
@@ -100,44 +103,46 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table)
 	}
 
 	if (szs[0] > 0)
-		cmdline = (CHAR8 *)(loaded_image->ImageBase + addrs[0]);
+		bt_cmdline = (CHAR8 *)(loaded_image->ImageBase + addrs[0]);
 
-	cmdline_len = szs[0];
+	bt_cmdline_len = szs[0];
 
-	/* if we are not in secure boot mode, or none was provided, accept a
-	 * custom command line and replace the built-in one */
-	if ((!secure || cmdline_len == 0) &&
-	    loaded_image->LoadOptionsSize > 0 &&
-	    use_shell_cmdline(cmdline_len) &&
-	    *(CHAR16 *)loaded_image->LoadOptions > 0x1F) {
-		CHAR16 *options;
-		CHAR8 *line;
-		UINTN i;
+	CHAR16 *options;
+	CHAR8 *line;
+	UINTN i;
+	options = (CHAR16 *)loaded_image->LoadOptions;
+	rt_cmdline_len = (loaded_image->LoadOptionsSize /
+		       sizeof(CHAR16)) * sizeof(CHAR8);
+	line = AllocatePool(rt_cmdline_len);
+	if (line == NULL) {
+		Print(L"Failed to allocate memory for command line");
+		return EFI_OUT_OF_RESOURCES;
 
-		options = (CHAR16 *)loaded_image->LoadOptions;
-		cmdline_len = (loaded_image->LoadOptionsSize /
-			       sizeof(CHAR16)) * sizeof(CHAR8);
-		line = AllocatePool(cmdline_len);
-		for (i = 0; i < cmdline_len; i++)
-			line[i] = options[i];
-		cmdline = line;
+	}
+	for (i = 0; i < rt_cmdline_len; i++)
+		line[i] = options[i];
+	rt_cmdline = line;
 
-		err = check_cmdline(cmdline, cmdline_len);
-		if (EFI_ERROR(err)) {
-			if (secure) {
-				Print(L"Custom kernel command line rejected\n");
-				return err;
-			} else {
-				Print(L"Custom kernel would be rejected in secure mode\n");
-			}
+	// allow for rt_cmdline_len to have included the terminating null
+	if (rt_cmdline_len > 1 && rt_cmdline[rt_cmdline_len-1] == '\0') {
+		rt_cmdline_len--;
+	}
+
+	err = get_cmdline_with_print(
+			secure, bt_cmdline, bt_cmdline_len, rt_cmdline, rt_cmdline_len,
+			&cmdline, &cmdline_len);
+	if EFI_ERROR(err) {
+		if (cmdline != NULL) {
+			FreePool(cmdline);
 		}
+		return err;
 	}
 
 	/* export the device path we are started from, if it's not set yet */
 	if (efivar_get_raw(&loader_guid, L"LoaderDevicePartUUID", NULL,
 			   NULL) != EFI_SUCCESS)
 		if (disk_get_part_uuid(loaded_image->DeviceHandle,
-				       uuid) == EFI_SUCCESS)
+				uuid) == EFI_SUCCESS)
 			efivar_set(L"LoaderDevicePartUUID", uuid, FALSE);
 
 	/* if LoaderImageIdentifier is not set, assume the image with this stub
@@ -180,6 +185,8 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table)
 	err = linux_exec(image, cmdline, cmdline_len,
 			 (UINTN)loaded_image->ImageBase + addrs[1],
 			 (UINTN)loaded_image->ImageBase + addrs[2], szs[2]);
+
+	FreePool(cmdline);
 
 	Print(L"Execution of embedded linux image failed: %r\n", err);
 	uefi_call_wrapper(BS->Stall, 1, 3 * 1000 * 1000);

--- a/stubby_efi.h
+++ b/stubby_efi.h
@@ -1,0 +1,9 @@
+#ifndef __STUBBY_EFI_H
+#define __STUBBY_EFI_H
+#ifdef LINUX_TEST
+#include "linux_efilib.h"
+#else
+#include <efi.h>
+#include <efilib.h>
+#endif
+#endif

--- a/stubby_efi.h
+++ b/stubby_efi.h
@@ -5,5 +5,9 @@
 #else
 #include <efi.h>
 #include <efilib.h>
+// older gnu-efi do not have UnicodeSPrint (Ubuntu 20.04 version 3.0.9-1)
+#ifndef UnicodeSPrint
+#define UnicodeSPrint(fmt, ...) SPrint(fmt, ##__VA_ARGS__)
+#endif
 #endif
 #endif

--- a/test-cmdline.c
+++ b/test-cmdline.c
@@ -6,7 +6,9 @@
 #include <stdlib.h>
 
 EFI_STATUS do_check_cmdline(const char* cmdline) {
-   return check_cmdline((unsigned char*)cmdline, strlen(cmdline));
+	CHAR16 emsg[256];
+	UINTN emsg_len = sizeof(emsg) / sizeof(emsg[0]);
+	return check_cmdline((unsigned char*)cmdline, strlen(cmdline), emsg, emsg_len);
 }
 
 typedef struct {
@@ -31,14 +33,14 @@ TestData tests[] = {
 };
 
 
-char* efiStatusStr(const EFI_STATUS n) {
+CHAR16* efiStatusStr(const EFI_STATUS n) {
 	if (n == EFI_SUCCESS)
-		return "allow";
+		return L"allow";
 	if (n == EFI_SECURITY_VIOLATION)
-		return "reject-S";
+		return L"reject-S";
 	if (n == EFI_OUT_OF_RESOURCES)
-		return "reject-R";
-	wprintf(L"FAIL: unknown number: '%ld'\n", n);
+		return L"reject-R";
+	Print(L"FAIL: unknown number: '%ld'\n", n);
 	exit(1);
 }
 
@@ -49,28 +51,28 @@ int main()
 	int fails = 0;
 	int passes = 0;
 	int num = sizeof(tests) / sizeof(tests[0]);
-	char nbuf[3];
-	wchar_t *fmt = L"%02s | %-4s | %-8s | %-8s |%s|\n";
+	CHAR16 nbuf[3];
+	CHAR16 *fmt = L"%02ls | %-4ls | %-8ls | %-8ls |%a|\n";
 
-	wprintf(fmt, "#", "rslt", "expect", "found", "cmdline");
+	Print(fmt, L"#", L"rslt", L"expect", L"found", "cmdline");
 	for (int i=0; i<num; i++) {
 		td = tests[i];
 		ret = do_check_cmdline(td.cmdline);
-		sprintf(nbuf, "%02d", i+1);
+		UnicodeSPrint(nbuf, 3, L"%02d", i+1);
 		if (ret == td.expected) {
-			wprintf(fmt, nbuf, "PASS",
+			Print(fmt, nbuf, L"PASS",
 					efiStatusStr(td.expected), efiStatusStr(ret),
 					td.cmdline);
 			passes++;
 		} else {
-			wprintf(fmt, nbuf, "FAIL",
+			wprintf(fmt, nbuf, L"FAIL",
 					efiStatusStr(td.expected), efiStatusStr(ret),
 					td.cmdline);
 			fails++;
 		}
 	}
 
-	wprintf(L"passed: %d. failed: %d\n", passes, fails);
+	Print(L"passed: %d. failed: %d\n", passes, fails);
 	if (fails != 0) {
 		return 1;
 	}

--- a/test-get-cmdline.c
+++ b/test-get-cmdline.c
@@ -1,0 +1,160 @@
+#include "stubby_efi.h"
+#include "kcmdline.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+typedef struct {
+	EFI_STATUS expstatus;
+	BOOLEAN secure;
+	char *builtin;
+	char *runtime;
+	char *expected;
+} TestData;
+
+#define ResultNotChecked "Result should not be checked"
+
+TestData tests[] = {
+	// all good secure
+	{EFI_SUCCESS, true,
+		"root=atomix STUBBY_RT_CLI1 more",
+		"console=ttyS0",
+		"root=atomix console=ttyS0 more"},
+	// no builtin, use runtime.
+	{EFI_SUCCESS, true,
+		"",
+		"root=atomix verbose",
+		"root=atomix verbose"},
+	// no builtin no runtime means empty.
+	{EFI_SUCCESS, true,
+		"",
+		"",
+		""},
+	// all good secure marker at beginning
+	{EFI_SUCCESS, true,
+		"STUBBY_RT_CLI1 root=atomix more",
+		"console=ttyS0",
+		"console=ttyS0 root=atomix more"},
+	// all good secure marker at end
+	{EFI_SUCCESS, true,
+		"root=atomix more STUBBY_RT_CLI1",
+		"console=ttyS0",
+		"root=atomix more console=ttyS0"},
+	// all good insecure
+	{EFI_SUCCESS, false,
+		"root=atomix STUBBY_RT_CLI1 more",
+		"console=ttyS0",
+		"root=atomix console=ttyS0 more"},
+	// secure, good builtin but bad runtime token result is not important.
+	{EFI_SECURITY_VIOLATION, true,
+		"root=atomix STUBBY_RT_CLI1 more",
+		"console=ttyS0 more",
+		ResultNotChecked},
+	// insecure, good builtin but bad runtime token.
+	{EFI_SECURITY_VIOLATION, true,
+		"root=atomix STUBBY_RT_CLI1 more2",
+		"console=ttyS0 more1",
+		ResultNotChecked},
+    // marker not a full token
+	{EFI_INVALID_PARAMETER, false,
+		"root=atomix STUBBY_RT_CLI1=abcd more",
+		"console=ttyS0",
+		ResultNotChecked},
+	// no marker in secureboot input
+	{EFI_INVALID_PARAMETER, true,
+		"root=atomix",
+		"console=ttyS0",
+		ResultNotChecked},
+	// no marker in insecure - just append.
+	{EFI_SUCCESS, false,
+		"root=atomix",
+		"console=ttyS0",
+		"root=atomix console=ttyS0"},
+	// namespace for marker found twice in builtin secure
+	{EFI_INVALID_PARAMETER, true,
+		"root=atomix STUBBY_RT debug STUBBY_RT_CLI1 ",
+		"console=ttyS0",
+        ResultNotChecked},
+	// namespace for marker found twice in builtin insecure
+	{EFI_INVALID_PARAMETER, false,
+		"root=atomix STUBBY_RT debug STUBBY_RT_CLI1 ",
+		"console=ttyS0",
+        ResultNotChecked},
+	// namespace appears in runtime
+	{EFI_INVALID_PARAMETER, false,
+		"root=atomix debug STUBBY_RT_CLI1",
+		"console=ttyS0 STUBBY_RT",
+        ResultNotChecked},
+};
+
+
+BOOLEAN do_get_cmdline(TestData td) {
+	EFI_STATUS status;
+	CHAR16 *errmsg;
+	CHAR8 *found;
+	UINTN found_len;
+	CHAR16 status_found[64];
+	CHAR16 status_exp[64];
+
+	// Print(L"builtin [%d] = '%a'\nruntime [%d] = '%a'\n", td.builtin, strlen(td.builtin), td.runtime, strlen(td.runtime));
+	status = get_cmdline(
+		td.secure, 
+		(CHAR8 *)td.builtin, strlen(td.builtin),
+		(CHAR8 *)td.runtime, strlen(td.runtime),
+		&found, &found_len,
+		&errmsg);
+
+	StatusToString(status_found, status);
+	StatusToString(status_exp, td.expstatus);
+
+	if (status != td.expstatus) {
+		Print(L"expected status '%ls' found '%ls'\n", status_found, status_exp);
+		Print(L"errmsg = %ls\n", errmsg);
+		return false;
+	}
+
+	// only care to check further for EFI_SUCCESS or EFI_SECURITY_VIOLATION
+	if ((status == EFI_SECURITY_VIOLATION && td.secure) ||
+			(status != EFI_SUCCESS && status != EFI_SECURITY_VIOLATION)) {
+		if (errmsg) {
+			free(errmsg);
+		}
+		return true;
+	}
+
+	// Print(L"%d/%d strcmp(%a, found)=%d\n", strlen(td.expected), found_len, td.expected, strcmp(td.expected, found));
+	if (strlen(td.expected) != found_len || strcmp(td.expected, (char *)found) != 0) {
+		Print(L"expected(%d): %a|\nfound   (%d): %a|\nerrmsg: %ls",
+				strlen(td.expected), td.expected, found_len, found, errmsg);
+		if (errmsg) {
+			free(errmsg);
+		}
+		return false;
+	}
+
+	return true;
+}
+
+int main()
+{
+	int num = sizeof(tests) / sizeof(tests[0]);
+	int passes = 0, fails = 0;
+
+	for (int i=0; i<num; i++) {
+		if (do_get_cmdline(tests[i])) {
+			passes++;
+		} else {
+			fails++;
+			Print(L"test %d FAIL\n", i);
+		}
+	}
+
+	if (fails != 0) {
+		return 1;
+	}
+
+	Print(L"passed: %d. failed: %d\n", passes, fails);
+	return 0;
+}

--- a/util.c
+++ b/util.c
@@ -25,9 +25,7 @@
  *
  */
 
-#include <efi.h>
-#include <efilib.h>
-
+#include "stubby_efi.h"
 #include "util.h"
 
 /* unique randomly generated UUID for stubby and related tools */

--- a/util.h
+++ b/util.h
@@ -28,8 +28,7 @@
 #ifndef __STUBBY_UTIL_H
 #define __STUBBY_UTIL_H
 
-#include <efi.h>
-#include <efilib.h>
+#include "stubby_efi.h"
 
 #define ELEMENTSOF(x) (sizeof(x)/sizeof((x)[0]))
 #define OFFSETOF(x,y) __builtin_offsetof(x,y)


### PR DESCRIPTION
Fixes https://github.com/puzzleos/stubby/issues/20.

If a stubby executable has a builtin command line that
includes the "marker" string STUBBY_RT_CLI1 as a whole token,
then any runtime command line will be placed in that position
in the kernel's command line.

As an example:

    builtin: foo=bar root=wark STUBBY_RT_CLI console=tty0
    runtime: console=ttyS0
    result: foo=bar root=wark console=ttyS0 console=tty0

Some things to note:
 * it seems fairly strange to me that get_cmdline_with_print
   is what is in charge of "allowing" the command line
   in insecure mode, but that made stub.c read better.
 * test-get-cmdline has reasonable test coverage (unverified)
   on the newly added code and further tests should be
   easy enough to add.
 * Also here is a re-work of the "linux_efilib" stuff.
   It is really odd, but when compiling with -DLINUX_TEST
   we end up with a CHAR16 being 4 bytes.  The whole reason
   is to avoid writing Print and UnicodeSPrint ourselves.
   The hack allows us to use wprintf and friends.

   The long term solution here would be to write CHAR16
   version of UnicodeSprint.