### PR TITLE
Feature: c-i boot test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,7 @@ jobs:
         run: |
           sudo apt-get update --quiet
           sudo apt-get install --quiet --assume-yes --no-install-recommends gnu-efi build-essential
+          sudo apt-get install --quiet --assume-yes --no-install-recommends dosfstools mtools ovmf qemu-system-x86 qemu-utils
       - name: Build
         run: |
           make build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,12 +13,43 @@ jobs:
         uses: actions/checkout@v2
       - name: Install Deps
         run: |
+          set -x
           sudo apt-get update --quiet
           sudo apt-get install --quiet --assume-yes --no-install-recommends gnu-efi build-essential
-          sudo apt-get install --quiet --assume-yes --no-install-recommends dosfstools mtools ovmf qemu-system-x86 qemu-utils
+          sudo apt-get install --quiet --assume-yes --no-install-recommends \
+              dosfstools mtools ovmf python3-minimal qemu-system-x86 qemu-utils shim-signed
+          mkdir ./test-inputs/
+          ./test/collect-firmwares --no-install ./test-inputs
+          ./test/get-krd ./test-inputs
+
       - name: Build
         run: |
           make build
+      - name: Upload Build
+        uses: actions/upload-artifact@v3
+        with:
+          path: |
+            stubby.efi
+
       - name: Unit Test
         run: |
           make test
+      - name: Boot Test
+        run: |
+          fails=""
+          for m in nvram efi-shell; do
+            echo "== $m =="
+            KVM=false ./test/harness run "--boot-mode=$m" \
+              --inputs=./test-inputs "--results=./test-results/$m" \
+              --sbat=sbat.csv --stubby=stubby.efi \
+              test/tests.yaml || fails="$fails $m"
+          done
+          [ -z "$fails" ] || { echo "FAIL: ${fails# }"; exit 1; }
+          exit 0
+
+      - name: Upload Test Results
+        uses: actions/upload-artifact@v3
+        with:
+          path: |
+            test-inputs/
+            test-results/

--- a/kcmdline.c
+++ b/kcmdline.c
@@ -58,7 +58,6 @@ EFI_STATUS check_cmdline(CONST CHAR8 *cmdline, UINTN cmdline_len, CHAR16 *errmsg
 	*errmsg = '\0';
 
 	CopyMem(buf, cmdline, cmdline_len);
-	// make sure it is null terminated.
 	buf[cmdline_len] = '\0';
 
 	// walk buf, populating tokens

--- a/kcmdline.c
+++ b/kcmdline.c
@@ -66,12 +66,12 @@ EFI_STATUS check_cmdline(CONST CHAR8 *cmdline, UINTN cmdline_len, CHAR16 *errmsg
 		c = buf[i];
 		if (c < 0x20 || c > 0x7e) {
 			UnicodeSPrint(errmsg, errmsg_len,
-				L"Bad character 0x%02hhx in position %d: %a.\n", c, i, cmdline);
+				L"Bad character 0x%02hhx in position %d: %a.", c, i, cmdline);
 			status = EFI_SECURITY_VIOLATION;
 			goto out;
 		}
 		if (i >= MAX_TOKENS) {
-			UnicodeSPrint(errmsg, errmsg_len, L"Too many tokens in cmdline.\n");
+			UnicodeSPrint(errmsg, errmsg_len, L"Too many tokens in cmdline.");
 			status = EFI_SECURITY_VIOLATION;
 			goto out;
 		}
@@ -97,7 +97,7 @@ EFI_STATUS check_cmdline(CONST CHAR8 *cmdline, UINTN cmdline_len, CHAR16 *errmsg
 
 	for (i=0; i < num_toks; i++) {
 		if (!is_allowed(tokens[i])) {
-			UnicodeSPrint(errmsg, errmsg_len, L"token not allowed: %a\n", tokens[i]);
+			UnicodeSPrint(errmsg, errmsg_len, L"token not allowed: %a", tokens[i]);
 			status = EFI_SECURITY_VIOLATION;
 		}
 	}
@@ -165,7 +165,7 @@ EFI_STATUS get_cmdline(
 				if (runtime_len != 0) {
 					status = EFI_INVALID_PARAMETER;
 					UnicodeSPrint(errbuf, errbuf_buflen,
-							L"runtime arguments cannot be given to non-empty builtin without marker\n");
+							L"runtime arguments cannot be given to non-empty builtin without marker");
 					goto out;
 				}
 			} else {
@@ -180,7 +180,7 @@ EFI_STATUS get_cmdline(
 			if (strstra(p + marker_len, marker) != NULL) {
 				status = EFI_INVALID_PARAMETER;
 				UnicodeSPrint(errbuf, errbuf_buflen,
-						L"%a appears more than once in builtin cmdline\n", marker);
+						L"%a appears more than once in builtin cmdline", marker);
 				goto out;
 			}
 
@@ -189,7 +189,7 @@ EFI_STATUS get_cmdline(
 			if (!((p == builtin || *(p - 1) == ' ') &&
 					(part2_len == 0 || *(p + marker_len) == ' '))) {
 				status = EFI_INVALID_PARAMETER;
-				UnicodeSPrint(errbuf, errbuf_buflen, L"%a is not a full token\n", marker);
+				UnicodeSPrint(errbuf, errbuf_buflen, L"%a is not a full token", marker);
 				goto out;
 			}
 
@@ -203,14 +203,14 @@ EFI_STATUS get_cmdline(
 	// namespace appeared in the builtin (other than marker)
 	if (strstra(part1, namespace) != NULL || strstra(part2, namespace) != NULL) {
 		status = EFI_INVALID_PARAMETER;
-		UnicodeSPrint(errbuf, errbuf_buflen, L"%a appears in builtin cmdline\n", namespace);
+		UnicodeSPrint(errbuf, errbuf_buflen, L"%a appears in builtin cmdline", namespace);
 		goto out;
 	}
 
 	// namespace appears in runtime
 	if (strstra(runtime, namespace) != NULL) {
 		status = EFI_INVALID_PARAMETER;
-		UnicodeSPrint(errbuf, errbuf_buflen, L"%a appears in runtime cmdline\n", namespace);
+		UnicodeSPrint(errbuf, errbuf_buflen, L"%a appears in runtime cmdline", namespace);
 		goto out;
 	}
 

--- a/kcmdline.c
+++ b/kcmdline.c
@@ -217,8 +217,10 @@ EFI_STATUS get_cmdline(
 	status = check_cmdline(runtime, runtime_len, errbuf, errbuf_buflen);
 
 	// EFI_SECURITY_VIOLATION is allowed if insecure boot, so continue on.
-	if ((status == EFI_SECURITY_VIOLATION && secure) || EFI_ERROR(status)) {
-		goto out;
+	if (EFI_ERROR(status)) {
+		if (status != EFI_SECURITY_VIOLATION || secure) {
+			goto out;
+		}
 	}
 
 	// At this point, part1 and part2 are set so we can just concatenate part1, runtime, part3
@@ -269,6 +271,10 @@ EFI_STATUS get_cmdline_with_print(
 	CHAR16 *errmsg = NULL;
 	EFI_STATUS err;
 
+	// Print(L"stubby loaded with secureboot=%a.\nbuiltin [%d]: %a\nruntime [%d]: %a\n",
+	//	secure ? "true" : "false",
+	//	builtin_len, (builtin_len != 0) ? builtin : (CHAR8*)"",
+	//	runtime_len, (runtime_len != 0) ? runtime : (CHAR8*)"");
 	err = get_cmdline(secure,
 		builtin, builtin_len, runtime, runtime_len,
 		cmdline, cmdline_len, &errmsg);

--- a/stra.c
+++ b/stra.c
@@ -12,3 +12,51 @@ CHAR8 *strstra(const CHAR8 *input, const CHAR8 *find) {
 	} while (*(input++) != '\0');
 	return NULL;
 }
+
+
+/* UEFI shell populates LoadOptions and LoadOptionsSize in some odd ways.
+ * One of which is that argv[0] (the name of the efi being executed) is
+ * present in the LoadOptions.
+ *
+ * This function simply removes the first token of the command line
+ * if that token ends with '.efi' or '.EFI'.
+ *
+ * parse_load_options in rhboot/shim/load-options.c has a good explanation
+ * of this as well as more complete code, but under different license.
+ *
+ * return FALSE if there is an error.
+ */
+BOOLEAN remove_leading_efi_name(CHAR8 *cmdline, UINTN *len_p) {
+	CHAR8 *p, *space;
+	UINTN len = *len_p, offset = 0, newlen = 0, i = 0;
+
+	space = strstra(cmdline, (CHAR8*)" ");
+	if (space == NULL)
+		return TRUE;
+
+	p = strstra(cmdline, (CHAR8*)".EFI ");
+	if (p == NULL) {
+		p = strstra(cmdline, (CHAR8*)".efi ");
+		if (p == NULL) {
+			return TRUE;
+		}
+	}
+
+	if (p > space)
+		return TRUE;
+
+	offset = ((space + 1) - cmdline);
+	newlen = len - offset;
+	if (newlen < 0) {
+		return FALSE;
+	}
+
+	for (i = 0; i < newlen; i++) {
+		cmdline[i] = cmdline[i + offset];
+	}
+
+	cmdline[newlen] = '\0';
+	*len_p = newlen;
+
+	return TRUE;
+}

--- a/stra.h
+++ b/stra.h
@@ -4,5 +4,6 @@
 #include "stubby_efi.h"
 
 CHAR8 *strstra(const CHAR8 *input, const CHAR8 *find);
+BOOLEAN remove_leading_efi_name(CHAR8 *cmdline, UINTN *len_p);
 
 #endif

--- a/stub.c
+++ b/stub.c
@@ -135,6 +135,11 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table)
 		if (cmdline != NULL) {
 			FreePool(cmdline);
 		}
+		// exiting with either SECURITY_VIOLATION or EFI_ACCESS_DENIED will result
+		// in shim trying to launch mok manager and a confusing "Not Found" error path.
+		if (err == EFI_SECURITY_VIOLATION || err == EFI_ACCESS_DENIED) {
+			err = EFI_INVALID_PARAMETER;
+		}
 		return err;
 	}
 

--- a/stub.c
+++ b/stub.c
@@ -31,6 +31,7 @@
 #include "kcmdline.h"
 #include "linux.h"
 #include "pe.h"
+#include "stra.h"
 #include "util.h"
 
 /* magic string to find in the binary image */
@@ -135,6 +136,11 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table)
 		rt_cmdline[i] = options[i];
 	}
 	rt_cmdline[rt_cmdline_len] = '\0';
+
+	if (!remove_leading_efi_name(rt_cmdline, &rt_cmdline_len)) {
+		Print(L"remove_leading_efi_name returned error\n");
+		return EFI_INVALID_PARAMETER;
+	}
 
 	err = get_cmdline_with_print(
 			secure, bt_cmdline, bt_cmdline_len, rt_cmdline, rt_cmdline_len,

--- a/test-get-cmdline.c
+++ b/test-get-cmdline.c
@@ -32,6 +32,11 @@ TestData tests[] = {
 		"",
 		"",
 		""},
+	// insecure, no builtin, bad runtime token allows runtime
+	{EFI_SECURITY_VIOLATION, false,
+		"",
+		"root=atomix verbose rootkit=yes",
+		"root=atomix verbose rootkit=yes"},
 	// all good secure marker at beginning
 	{EFI_SUCCESS, true,
 		"STUBBY_RT_CLI1 root=atomix more",
@@ -126,7 +131,7 @@ BOOLEAN do_get_cmdline(TestData td) {
 
 	// Print(L"%d/%d strcmp(%a, found)=%d\n", strlen(td.expected), found_len, td.expected, strcmp(td.expected, found));
 	if (strlen(td.expected) != found_len || strcmp(td.expected, (char *)found) != 0) {
-		Print(L"expected(%d): %a|\nfound   (%d): %a|\nerrmsg: %ls",
+		Print(L"expected(%d): %a|\nfound   (%d): %a|\nerrmsg: %ls\n",
 				strlen(td.expected), td.expected, found_len, found, errmsg);
 		if (errmsg) {
 			free(errmsg);

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,110 @@
+# OVMF Boot VM test
+
+Running test consists of
+ * collecting the inputs to test
+ * running test harness
+
+## Collecting Inputs
+Getting inputs in order to run test suite
+
+    $ mkdir inputs
+    $ cd inputs
+
+    # As of 2022-09 this only works on Ubuntu focal due to
+    # https://bugs.launchpad.net/bugs/1986692
+    $ sudo ../tools/collect-firmwares .
+
+    $ ../tools/get-krd .
+
+### Detailed info.
+Inputs to the test harness are:
+
+ * firmwares - this includes OVMF vars and OVMF code files as well as signing keys.
+   These can be created by running with 'test/collect-firmwares' on ubuntu.  The
+   collect-firmwares program installs the required packages and collects the required
+   files.
+
+       sudo ./tools/collect-firmwares firmwares
+
+   Files used from the firmwares are:
+
+    *  firmwares/ovmf-insecure-code.fd
+    *  firmwares/ovmf-insecure-vars.fd
+    *  firmwares/ovmf-secure-vars.fd
+    *  firmwares/ovmf-secure-code.fd
+    *  firmwares/signing.key - encrypted signing key.
+    *  firmwares/signing.pem - signing certificate. executables signed by this certificate
+       are expected to run in secureboot mode inside vm using ovmf-secure files.
+    *  firmwares/signing-unlocked.key - an unlocked (no password version) of signingkey
+    *  firmwares/signing.password - contains plaintext password to unlock the signing.key
+    *  firmwares/firmware-info.yaml - provides information on where files came from.
+
+ * kernel and initramfs.  These can be downloaded with 'get-krd'.  The kernel and initramfs
+   are smashed into a stubby executable and executed from EFI.
+
+    * kernel
+    * initramfs - the initramfs is expected to print the kernel command line and power off system.
+
+
+## Running test
+Typical running of test would be:
+
+    $ ./test/harness run \
+        --inputs=./inputs --results=./results \
+        --sbat=sbat.csv --stubby=stubby.efi \
+        test/tests.yaml
+
+That will execute the tests described in tests.yaml using the provided
+inputs, sbat, stubby and write results to results/.
+
+
+## test 'mode'
+Based on the 'shim' value in test data, the harness will execute either:
+
+  * `shim.efi kernel.efi [options]` or
+  * `kernel.efi [options]`
+
+The tests can execute that "first loader" program in one of 2 modes.
+
+  * **uefi-shell**: This uses a startup.nsh style script to execute
+    either shim.efi or kernel.efi. The efi shell (at least from ovmf)
+    executes programs differently than nvram.
+
+  * nvram: This uses a startup.nsh script to control the boot order
+    via the 'bcmd' command in the efi shell.  The desired boot parameter
+    are added to an nvram entry and then a reboot is done.  This path
+    is more similar to what you would get on an installed system.
+
+## test.yaml structure
+See the comment at the top of tests.yaml for more information.
+
+Notes:
+ * jammy ovmf files with snakeoil are broken
+   https://bugs.launchpad.net/ubuntu/+source/edk2/+bug/1986692
+ * each run/<testdir> has a 'boot' script that can be run and will run the
+   test interactively.  that's nice for getting to sehll and seeing things.
+ * in the future it'd be nice if the boot script could potentially re-generate the
+   esp.img if you made changes.
+ * qemu is executed with 'snapshot' on for each of the modifiable items
+   (efi image and nvram).  This means that if you kept a working directory
+   around to use 'boot', the files will be in their original state.
+
+ * there are really 3 "modes" of boot.  "first loader" indicates either shim.efi
+   (which then loads kernel.efi) or kernel.efi directly:
+   * first loader specified in nvram entry (bcfg or efibootmgr)
+   * first loader executed from startup.nsh script
+   * first loader named bootx64.efi finds grubx64.efi .. no current way for
+     cmdline arguments this way.  This is how a removable media would operate.
+     We'd talked about potentially having a simplistic menu or something to
+     read a file and pick one from a list.
+
+ * In 'uefi-shell' boot mode:
+   * startup.nsh is selected for execution by the bootloader (special well known name)
+   * startup.nsh runs 'launch.nsh' - this is because a .nsh script will
+     effectively run with "set -e" unless it is called by another nsh
+     script.  This is crazy but true.  So instead of just having
+     startup.nsh launch our efi directly, we have it launch launch.nsh
+
+     after executing launch.nsh, startup.nsh will shutdown.
+
+   * launch.nsh will either execute launches the "first loader"

--- a/test/boot-vm
+++ b/test/boot-vm
@@ -1,0 +1,96 @@
+#!/bin/bash
+# shellcheck disable=SC2015,SC2039,SC2046,SC2086,SC2166,SC3043
+TEMP_D=""
+OVMFCODE=/usr/share/OVMF/OVMF_CODE.fd
+SB_OVMFVARS=/usr/share/OVMF/OVMF_VARS.snakeoil.fd
+IB_OVMFVARS=/usr/share/OVMF/OVMF_VARS.fd
+
+OVMFCODE=/usr/share/OVMF/OVMF_CODE_4M.secboot.fd
+OVMFCODE=/usr/share/OVMF/OVMF_CODE_4M.fd
+SB_OVMFVARS=/usr/share/OVMF/OVMF_VARS_4M.snakeoil.fd
+IB_OVMFVARS=/usr/share/OVMF/OVMF_VARS_4M.fd
+
+Usage() {
+    cat <<EOF
+${0##*/} [options] disk-image
+
+   execute qemu uefi, booting from disk-image.
+
+   options:
+     -v | --verbose       be more verbose
+     -s | --secureboot    boot using secureboot.
+EOF
+}
+
+fail() { echo "$@" 1>&2; exit 1; }
+
+cleanup() {
+    [ -d "$TEMP_D" ] || rm -Rf "$TEMP_D"
+}
+
+main() {
+    local sopts="hsv" o=""
+    local lopts="help,secureboot,verbose"
+    o=$(getopt "--name=${0##*/}" "--options=$sopts" "--long=$lopts" -- "$@") &&
+        eval set -- "$o" || { bad_Usage; return; }
+
+	local cur="" secureboot=false ovmfvars=""
+
+	while [ $# -ne 0 ]; do
+        cur="$1"
+		case "$cur" in
+			-h|--help) Usage ; exit 0;;
+			-s|--secureboot) secureboot=true;;
+			-v|--verbose) VERBOSITY=$((VERBOSITY+1));;
+			--) shift; break;;
+		esac
+		shift;
+	done
+    [ $# -eq 2 ] || { Usage 1>&2; return 1; }
+
+    local esp="$1" log="$2"
+    [ -f "$esp" ] || fail "esp '$esp': not a file"
+    espfp=$(readlink -f "$esp") || fail "failed to get full path to $esp"
+
+    TEMP_D=$(mktemp -d "${TMPD:-/tmp/${0##*/}.XXXXXX}") || fail "failed to mktemp"
+    trap cleanup EXIT
+    rund="${TEMP_D}/run"
+
+    mkdir "$rund" || fail "failed to make run dir"
+
+    [ "$secureboot" = "true" ] &&
+        ovmfvars="${SB_OVMFVARS}" || ovmfvars="${IB_OVMFVARS}"
+
+    cp -v "$OVMFCODE" "$rund/ovmf-code.fd" ||
+        fail "failed to copy ovmf code to run-dir"
+    cp -v "$ovmfvars" "$rund/ovmf-vars.fd" ||
+        fail "failed to copy ovmf vars to run-dir"
+
+    # create a qcow backed by the input file.
+    # This means we don't change it and is sort of a "fast copy"
+    qemu-img create -f qcow2 -b "$espfp" -F raw "$rund/esp.qcow2" ||
+        fail "failed to create esp qcow"
+
+    # other useful flags:
+    #  -device VGA -vnc :9000
+    #   -object rng-random,filename=/dev/urandom,id=rng0 \
+    #   -device virtio-rng-pci,rng=rng0 \
+    #
+    #  this flag may allow you to toggle secure boot on or off:
+    #     -global driver=cfi.pflash01,property=secure,value=on
+    set -- \
+    qemu-system-x86_64 \
+        -enable-kvm -m 1024 -serial mon:stdio \
+        -vnc none \
+        -nic none \
+        -drive "if=pflash,format=raw,file=$rund/ovmf-code.fd,readonly" \
+        -drive "if=pflash,format=raw,file=$rund/ovmf-vars.fd" \
+        -drive "file=$rund/esp.qcow2,id=disk00,if=none,format=qcow2,index=0" \
+        -device "virtio-blk,drive=disk00,serial=esp.img"
+
+    echo "$*" > "$log" || fail "failed to write to $log"
+    echo "executing:" "$@" 1>&2
+    #timeout --foreground 2m "$@"
+}
+
+main "$@"

--- a/test/collect-firmwares
+++ b/test/collect-firmwares
@@ -1,0 +1,114 @@
+#!/bin/sh
+# shellcheck disable=SC2166
+fail() { echo "$@" 1>&2; exit 1; }
+Usage() {
+    cat <<EOF
+Usage: ${0##*/} outd [rel]
+
+Grab stuff from system into outd.
+EOF
+}
+
+info() {
+    echo "release: $REL"
+    echo "packages:"
+    for p in ovmf shim-signed ; do
+        v=$(dpkg-query --show --showformat='${Version}' "$p") ||
+            fail "failed to get version for $p"
+        echo "  $p: \"$v\""
+    done
+}
+
+[ "$1" = "-h" -o "$1" = "--help" ] && { Usage; exit 0; }
+
+[ "$1" = "--no-install" ] && install=false && shift || install=true
+[ $# -ge 1 ] || fail "must give output dir"
+outd="$1"
+REL="$2"
+if [ -z "$REL" ]; then
+    REL=$(lsb_release -sc) || fail "must give rel, couldn't figure out"
+fi
+set --
+
+[ -d "$outd" ] || mkdir "$outd" ||
+    fail "failed to make output dir"
+
+if [ "$install" = "true" ]; then
+    [ "$(id -u)" = "0" ] ||
+        fail "must be root for install (try sudo or --no-install)"
+    apt-get update --quiet || fail "apt-get update failed."
+    apt-get install --quiet \
+        --assume-yes --no-install-recommends \
+        ovmf shim-signed ||
+        fail "failed install deps"
+else
+    echo "skipping install"
+fi
+
+set --
+set -- "$@" \
+   "/usr/share/ovmf/PkKek-1-snakeoil.pem" \
+   "signing.pem|link:PkKek-1-snakeoil.pem" \
+   "/usr/share/ovmf/PkKek-1-snakeoil.key" \
+   "signing.key|link:PkKek-1-snakeoil.key" \
+   "signing.password|text:snakeoil"
+
+bd=/usr/share/OVMF
+case "$REL" in
+    jammy)
+        set -- "$@" \
+            "$bd/OVMF_VARS_4M.fd" \
+            "$bd/OVMF_CODE_4M.secboot.fd" \
+            "$bd/OVMF_VARS_4M.snakeoil.fd" \
+            "ovmf-insecure-code.fd|link:OVMF_CODE_4M.secboot.fd" \
+            "ovmf-insecure-vars.fd|link:OVMF_VARS_4M.fd" \
+            "ovmf-secure-code.fd|link:OVMF_CODE_4M.secboot.fd" \
+            "ovmf-secure-vars.fd|link:OVMF_VARS_4M.snakeoil.fd"
+        ;;
+    focal)
+        set -- "$@" \
+            "$bd/OVMF_VARS.fd" \
+            "$bd/OVMF_CODE.secboot.fd" \
+            "$bd/OVMF_VARS.snakeoil.fd" \
+            "ovmf-insecure-code.fd|link:OVMF_CODE.secboot.fd" \
+            "ovmf-insecure-vars.fd|link:OVMF_VARS.fd" \
+            "ovmf-secure-code.fd|link:OVMF_CODE.secboot.fd" \
+            "ovmf-secure-vars.fd|link:OVMF_VARS.snakeoil.fd"
+        ;;
+    *) fail "unknown release $REL";;
+esac
+
+for line in "$@"; do
+    case "$line" in
+        *\|*)
+            target="${line%%|*}"
+            src=${line#*|};;
+        *)
+            target=${line##*/}
+            src="$line";;
+    esac
+    case "$src" in
+        text:*)
+        src=${src#text:}
+            printf "%s" "$src" > "$outd/$target" || fail "failed to write $target"
+            echo "wrote $target from text"
+        ;;
+        link:*)
+            src=${src#link:}
+            ln -s "$src" "$outd/$target" || fail "failed link $src -> $target"
+            echo "linked $target -> $src"
+        ;;
+        *)
+            cp "$src" "$outd/$target" || fail "failed copy $src -> $target"
+            echo "copied $src to $target"
+        ;;
+    esac
+done
+
+openssl rsa -passin stdin \
+    -in "$outd/signing.key" \
+    -out "$outd/signing-unlocked.key" < "$outd/signing.password" ||
+    fail "failed to decrypt signing key"
+
+info > "$outd/firmware-info.yaml"
+echo "wrote info to firmware-info.yaml"

--- a/test/gen-esp
+++ b/test/gen-esp
@@ -1,0 +1,142 @@
+#!/bin/bash
+# shellcheck disable=SC2015,SC2039,SC2046,SC2086,SC2166,SC3043
+CR='
+'
+Usage(){
+    cat <<EOF
+${0##*/} create [--size=128MB] output path[:targetpath] ...
+
+   if targetpath is not provided for a path, then
+   default of 'efi/boot/bootx64.efi' is used.
+
+   if there are no '/' in targetpath, then efi/boot/
+   is assumed.
+
+Also support 'update' with:
+
+    ${0##*/} update existing.img path:targetpath ...
+EOF
+}
+
+fail() { echo "$@" 1>&2; exit 1; }
+stderr() { echo "$@" 1>&2; }
+cleanup() {
+    [ -n "$TMPD" ] || return 0
+    rm -Rf "${TMPD}"
+}
+
+create() {
+    local size="128MB" staged=""
+    case "$1" in
+        --size=*) size="${1#--size=}"; shift;;
+    esac
+    rm -f "$img" || return 1
+    stderr "creating image ${size} in $img"
+    fallocate "--length=$size" "$img" || return 1
+    out=$(mkfs.fat "$img" 2>&1) || {
+        stderr "failed mkfs.fat $img: $out"
+        return 1
+    }
+    return 0
+}
+
+
+# update([--size=128MB,] output, file[:file] ...)
+#   create file 'output' of size 'size'.
+#   copy files provided to target.  files are 'src:dest'
+#   if no dest is given, default is efi/boot/bootx64.efi
+#   all filenames in image are converted to upper case.
+update() {
+    local img="$1" f="" src="" dest="" destd="" out=""
+    shift
+    staged="${TMPD}/genesp"
+    rm -Rf "$staged" || return 1
+
+    # create a staging directory with renamed files.
+    for f in "$@"; do
+        src="${f%%:*}"
+        dest="${f#*:}"
+        case "$dest" in
+            */*) :;;
+            *) dest="efi/boot/$dest";;
+        esac
+        out=$(echo "$dest" | tr '[:lower:]' '[:upper:]') && dest="$out" || {
+            stderr "failed to convert '$dest' to upper case"
+            return 1
+        }
+        destd=$(dirname "$dest")
+        mkdir -p "$staged/$destd" || {
+            stderr "failed to stage dir '$dest'"
+            return 1
+        }
+        cp "$src" "$staged/$dest" || {
+            stderr "failed to stage cp $src -> $dest"
+            return 1
+        }
+    done
+
+    # shellcheck disable=SC2035
+    ( cd "$staged" && find * -type f ) > "${TMPD}/list" || {
+        stderr "failed t find stage files";
+        return 1;
+    }
+
+    # shellcheck disable=SC2035
+    dirs=$( cd "$staged" && find * -type d ) > "${TMPD}/dirs" || {
+        stderr "failed to find dirs"
+        return 1;
+    }
+
+    local oifs="$IFS"
+    IFS="${CR}"; set -- $dirs; IFS="$oifs"
+
+    mmd -D s -i "$img" "$@" >/dev/null 2>&1 || {
+        # if a dir exists, it will fail. just ignore this.
+        # assuming things will fail later.
+        :
+    }
+
+    # shellcheck disable=SC2162
+    while read f; do
+        echo "$f -> $f" 1>&2
+        mcopy -D o -Q -i "$img" "${staged}/$f" "::$f" || {
+            stderr "mcopy failed $f -> $f";
+            return 1;
+        }
+    done < "${TMPD}/list"
+
+    rm -Rf "$staged" || {
+        stderr "failed to remove $staged"
+        return 1
+    }
+}
+
+[ $# -eq 0 ] && { Usage 1>&2; exit 1; }
+[ "$1" = "-h" -o "$1" = "--help" ] && { Usage; exit 0; }
+
+out=$( { command -v mcopy && command -v mkfs.vfat; } 2>&1) ||
+    fail "missing deps: ${out}"
+
+TMPD=$(mktemp -d "${TMPDIR:-/tmp}/${0##*/}.XXXXXX") ||
+    fail "failed mktemp"
+trap cleanup EXIT
+
+case "$1" in
+    create)
+        shift
+        sizef=""
+        case "$1" in
+            size=*) sizef="$1"; shift;;
+        esac
+        img="$1"
+        shift
+        create ${sizef:+"$sizef"} "$img" || fail "failed create $sizef $1"
+        if [ $# -ne 0 ]; then
+            update "$img" "$@"
+        fi
+        ;;
+    update)
+        shift;
+        update "$@";;
+    *) fail "Unknown cmd '$1'";;
+esac

--- a/test/get-krd
+++ b/test/get-krd
@@ -1,0 +1,131 @@
+#!/bin/bash
+# shellcheck disable=SC2015,SC2166,SC2181,SC2162
+set -o pipefail
+TEMP_D=""
+CIRROS_VERSION=${CIRROS_VERSION:-0.5.2}
+CIRROS_ARCH=${CIRROS_ARCH:-x86_64}
+CIRROS_MIRROR="http://download.cirros-cloud.net/"
+
+Usage() {
+    cat <<EOF
+Usage: ${0##*/} [outd]
+
+  downloads cirros kernel at ${CIRROS_VERSION} to outd.
+
+  if not provided, 'outd' defaults to '.'.
+
+  creates:
+    outd/kernel           a cirros kernel
+    outd/initrd.dist   an unmodified cirros initramfs
+    outd/initrd        an updated initramfs that shuts itself off.
+EOF
+}
+
+cleanup(){
+    [ ! -d "${TEMP_D}" ] || rm -Rf "${TEMP_D}"
+}
+
+mkcpio() {
+    local tmpf="" rc=0
+    tmpf=$(mktemp "${TMPDIR:-/tmp}/${0##*/}.XXXXXX") || {
+        stderr "failed to create tmp file"
+        return 1
+    }
+    (for f in "$@"; do echo "$f"; done |
+        cpio --create --owner=+0:+0 -H newc ) 2>"$tmpf"
+    rc=$?
+    [ $rc -eq 0 ] || {
+        stderr "failed cpio create newc:"
+        cat "$tmpf" 1>&2
+    }
+    rm -f "$tmpf"
+    return $rc
+}
+
+write_init() {
+    cat > "$1" <<"EOF"
+#!/bin/sh
+msg() { 
+    local d="" written=false
+    for d in /dev/ttyS0 /dev/tty1; do
+        [ -c "$d" ] || continue
+        echo "$@" >"$d" 2>&1 && written=true;
+    done
+    [ "$written" = "true" ] && return 0
+    echo "$@"
+}
+panic() {
+    msg "FATAL:" "$@"
+}
+
+msg "==== MINI INITRAMFS INIT ===="
+mkdir -p /proc /dev /tmp /sys
+mount -t devtmpfs /dev /dev ||
+    panic "failed mount devtmpfs"
+mount -t proc /proc /proc ||
+    panic "failed mount proc"
+mount -t sysfs /sys /sys ||
+    panic "failed mount /sys"
+
+echo "6 4 1 7" >/proc/sys/kernel/printk
+
+read cmdline < /proc/cmdline ||
+    panic "failed to read cmdline"
+
+environ=$(tr '\0' ' ' </proc/1/environ) ||
+    panic "failed to read /proc/1/environ"
+
+msg "/INIT COMMAND LINE:" "$0" "$@"
+msg "/INIT ENVIRON:" "$environ"
+msg "KERNEL COMMAND LINE:" "$cmdline"
+
+echo o >/proc/sysrq-trigger
+
+read || panic "Read returned $?"
+panic "Read returned success; What to do now?"
+exit 1
+EOF
+    [ $? -eq 0 ] || return 1
+    chmod 755 "$1"
+}
+
+fail() { stderr "$@"; exit 1; }
+stderr() { echo "$@" 1>&2; }
+
+[ "$1" = "-h" -o "$1" = "--help" ] && { Usage; exit 0; }
+[ $# -gt 1 ] && { Usage 1>&2; stderr "got $# args."; exit 1; }
+
+outd=${1:-.}
+[ -d "$outd" ] || mkdir -p "$outd" || fail "failed to create $outd"
+cd "$outd" || fail "could not cd '$outd'"
+
+TEMP_D=$(mktemp -d "${TMPDIR:-/tmp}/${0##*/}.XXXXXX") ||
+    fail "could not make a temp dir"
+trap cleanup EXIT
+
+burl="${CIRROS_MIRROR}/${CIRROS_VERSION}"
+for toks in kernel initramfs:initrd.dist; do
+    rname=${toks%:*}
+    lname=${toks#*:}
+    cname="cirros-${CIRROS_VERSION}-${CIRROS_ARCH}-$rname"
+    [ -f "$lname" ] && {
+        stderr "using cached $outd/$lname"
+        continue;
+    }
+    wget "$burl/$cname" -O "$lname.tmp" &&
+        mv "$lname.tmp" "$lname" || {
+            rm -f "$lname.tmp"
+            fail "failed to download $lname from $burl/$cname"
+        }
+done
+
+init="${TEMP_D}/init"
+write_init "$init" || fail "failed to write init to file"
+( zcat initrd.dist && cd "${TEMP_D}" && mkcpio init ) |
+    gzip -c > "initrd.tmp" &&
+    mv "initrd.tmp" "initrd" || {
+        rm -f "initrd.tmp"
+        fail "failed to create initrd"
+    }
+stderr "created ${outd%/}/initrd with 'init'"
+exit

--- a/test/harness
+++ b/test/harness
@@ -1,0 +1,826 @@
+#!/usr/bin/env python3
+import argparse
+import codecs
+import functools
+import logging
+import os.path
+import re
+import shlex
+import shutil
+import signal
+import subprocess
+import sys
+import threading
+import tempfile
+import time
+import yaml
+
+
+MODE_NVRAM = 'nvram'
+MODE_UEFI_SHELL = 'efi-shell'
+
+TMP_PREFIX = "stubbytest."
+STARTUP_NSH_UEFI_SHELL = r"""setvar SecureBoot
+fs0:
+cd fs0:\efi\boot
+launch.nsh
+reset -s "exited with %lasterror%"
+"""
+
+STARTUP_NSH_NVRAM = r"""setvar SecureBoot
+fs0:
+cd fs0:\efi\boot
+bcfg boot rm 00
+bcfg boot add 00 {efi} harness-efi
+bcfg boot -opt 0x0 boot.opts
+#type boot.opts
+#bcfg boot dump -v
+mv startup.nsh startup.nsh.orig
+cp shutdown.nsh startup.nsh
+echo -off
+echo "rebooting into: {efi} {args}"
+reset -c "reboot-into-harness-efi: {efi} {args}"
+"""
+
+SHUTDOWN_NSH_CONTENT = r"""reset -s shutdown-from-shutdown-nsh"""
+
+ANSI_ESCAPE = re.compile(b'(?:\x1b[@-_]|[\x80-\x9f])[0-?]*[ -/]*[@-~]')
+
+
+def booted_runtime_cli(_name, tdata, result):
+    """Validate that linux's /proc/cmdline should be identical to tdata[runtime]"""
+    kcmdline = result.kernel_cmdline()
+    if kcmdline != tdata["runtime"]:
+        raise TestError("\n".join([
+            "kernel command line differed from runtime",
+            " expected: '" + tdata["runtime"] + "'",
+            " found   : '" + kcmdline + "'",
+            ]) + "\n")
+
+
+def booted_expected_cli(_name, tdata, result):
+    """Validate that linux's /proc/cmdline should be identical to tdata[expected]"""
+    kcmdline = result.kernel_cmdline()
+    if kcmdline != tdata["expected"]:
+        raise TestError("\n".join([
+            "kernel command line differed from runtime",
+            " expected: '" + tdata["runtime"] + "'",
+            " found   : '" + kcmdline + "'",
+            ]) + "\n")
+
+
+def warned_cmdline(_name, _tdata, result):
+    """Validate that stubby wrote a warning before loading kernel."""
+    if result.is_warned() is True:
+        return
+    raise TestError("boot did not warn")
+
+
+def denied_boot(_name, _tdata, result):
+    """Validate that stubby refused to boot"""
+    if result.is_rejected() is True:
+        return
+    raise TestError("boot was not denied")
+
+
+def load_test_data(testfile):
+    testdata = yaml.safe_load(read_file(testfile))
+
+    if not isinstance(testdata, dict):
+        raise ValueError(f"top level entry in test data from {testfile} is not a dict")
+
+    fields = {
+        "builtin": (str, lambda n: ""),
+        "sb": (bool, lambda n: name.startswith("sb-")),
+        "shim": (bool, lambda n: n.startswith("sb-shim") or n.startswith("ib-shim")),
+        "runtime": (str, None),
+        "assert": (list, None),
+        "name": (str, None)
+    }
+
+    errors = []
+    tests = []
+    if 'tests' in testdata:
+        tests = testdata['tests']
+    else:
+        errors.append(f"No 'tests' key found in {testfile}")
+
+    names = set()
+    for tnum, td in enumerate(tests):
+        name = td.get("name")
+        if name == "" or name is None:
+            errors.append(f"test number {tnum} has no name")
+            continue
+        if name in names:
+            errors.append(f"name {name} appears multiple times (num {tnum})")
+        names.add(name)
+        for fname, (ftype, namebased) in fields.items():
+            if fname not in td:
+                # allow defaults based on name for shorter yaml
+                if namebased is None:
+                    errors.append(f"{name}: missing field {fname}")
+                else:
+                    td[fname] = namebased(name)
+            elif not isinstance(td.get(fname), ftype):
+                found = td.get(fname).__class__.__name__
+                errors.append(f"{name}: {fname}: is type '{found}', expected {ftype}")
+
+        for num, assertion in enumerate(td.get("assert", [])):
+            if assertion not in CHECKS:
+                errors.append(f"{name}: assertion {num} ({assertion}) is invalid")
+
+    if len(errors) != 0:
+        raise ValueError(
+            ("Errors validating test data in " + testfile + ":\n  " +
+              "\n  ".join(errors) + "\n"))
+
+    return testdata
+
+
+CHECKS = {
+    "booted-runtime-cli": booted_runtime_cli,
+    "booted-expected-cli": booted_expected_cli,
+    "warned-cmdline": warned_cmdline,
+    "denied-boot": denied_boot,
+}
+
+
+def escape_ansi(data):
+    replaces = (
+        (b'\x1b\x5b\x30\x39\x3b\x30\x31\x48', b'\n'),  # before 'Press any key'
+        (b'\x0d', b''),  # ctrl-M / carriage return
+    )
+    for src, dest in replaces:
+        data = data.replace(src, dest)
+    return ANSI_ESCAPE.sub(b'', data)
+
+
+def first_file(*files):
+    for fname in files:
+        if os.path.exists(fname):
+            return fname
+    return None
+
+
+class SubpResult():
+    cmd, data, duration, exception = (None, None, None, None)
+    out, err = (b'', b'')
+    rc = -1
+
+    def __init__(self, **kwargs):
+        bad = ','.join([k for k in kwargs if not hasattr(self, k)])
+        if bad:
+            raise AttributeError(
+                f"{self.__class__.__name__} object has no attributes: {bad}")
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+    def __str__(self):
+        def indent(name, data):
+            if data is None:
+                return "{name}: {data}"
+
+            if hasattr(data, 'decode'):
+                data = data.decode('utf-8', errors='ignore')
+
+            return "%s: %s" % (
+                name,
+                ''.join(["  " + line + "\n" for line in data.splitlines()]))
+
+        return '\n'.join([
+            "cmd: %s" % '' if not self.cmd else shell_quote(self.cmd),
+            f"rc: {self.rc}",
+            "duration: %.2fs" % self.duration,
+            "exc: %s" % self.exception,
+            indent("stdout", self.out),
+            indent("stderr", self.err),
+            ""])
+
+
+class SubpError(Exception):
+    def __init__(self, result, desc=None):
+        super(SubpError, self).__init__(desc)
+        self.desc = desc
+        self.result = result
+
+    def __str__(self):
+        ret = "" if not self.desc else "desc: %s\n" % self.desc
+        ret += "" if not self.result.exception else "exception: %s\n" % self.result.exception
+        return ret + str(self.result)
+
+
+def shell_quote(cmd):
+    return ' '.join(shlex.quote(a) for a in cmd)
+
+
+def subp(cmd, capture=True, data=None, rcs=(0,), timeout=None, ksignal=signal.SIGTERM,
+         cwd=None, stdout=None, stderr=None):
+    """Execute a subprocess.
+
+    cmd: string or list to execute.  string is not split.
+    capture: capture and return stdin and stdout in the SubpResult
+    data: stdin to the process.
+    rcs: list of exit codes that should not raise exception.
+    timeout: maximum time in seconds for process to finish.
+    ksignal: the signal to send to the process. Standard Popen interface
+            always sends SIGKILL, which does not allow process to clean up.
+
+    Return is a SubpResult.
+    If rcs is provided and exit code is not in the list of rcs, then
+    a SubpError is raised.
+    """
+    if isinstance(rcs, int):
+        rcs = (rcs,)
+
+    # allow user to pass in a string as data
+    if hasattr(data, 'encode'):
+        data = data.encode('utf-8')
+
+    devnull_fp = None
+    stdin = subprocess.PIPE
+    if capture:
+        stdout, stderr = (subprocess.PIPE, subprocess.PIPE)
+
+    result = SubpResult(cmd=cmd, rc=-1)
+    start = time.time()
+    try:
+        if data is None:
+            # devnull ensures any read gets null and wont ever block.
+            devnull_fp = open(os.devnull, "rb")
+            stdin = devnull_fp
+
+        logging.debug("Executing: %s", shell_quote(cmd))
+        sp = subprocess.Popen(
+            cmd, stdout=stdout, stderr=stderr, stdin=stdin, cwd=cwd)
+
+        def communicate():
+            try:
+                (result.out, result.err) = sp.communicate(data)
+            except Exception as e:
+                result.exception = e
+
+        if timeout is not None and ksignal != signal.SIGKILL:
+            thread = threading.Thread(target=communicate)
+            thread.start()
+            thread.join(timeout)
+            if thread.is_alive():
+                sp.send_signal(ksignal)
+                thread.join()
+                result.exception = subprocess.TimeoutExpired(cmd=cmd, timeout=timeout)
+        else:
+            communicate()
+
+        result.rc = sp.returncode
+
+        if not result.out:
+            result.out = b''
+        if not result.err:
+            result.err = b''
+
+    finally:
+        result.duration = time.time() - start
+        if devnull_fp:
+            devnull_fp.close()
+
+    logging.debug("returned %d took %.2fs", result.rc, result.duration)
+    if rcs is None or result.rc in rcs:
+        return result
+    else:
+        raise SubpError(result)
+
+
+def _check_run_args(cliargs):
+    checks = (
+        ("kernel", "kernel", None),
+        ("initrd", "initrd", None),
+        ("stubby", "stubby.efi", None),
+        ("sbat", "sbat.csv", None),
+        ("shim", "shim.efi",
+            lambda: first_file("/usr/lib/shim/shimx64.efi")),
+        ("signing_key", "signing.key",
+            lambda: first_file("/usr/share/ovmf/PkKek-1-snakeoil.key")),
+        ("signing_cert", "signing.pem",
+            lambda: first_file("/usr/share/ovmf/PkKek-1-snakeoil.pem")),
+        ("ovmf_secure_code", "ovmf-secure-code.fd",
+            lambda: first_file(
+                "/usr/share/OVMF/OVMF_CODE_4M.snakeoil.fd",
+                "/usr/share/OVMF/OVMF_CODE.fd",
+                )),
+        ("ovmf_secure_vars", "ovmf-secure-vars.fd",
+            lambda: first_file(
+                "/usr/share/OVMF/OVMF_VARS_4M.snakeoil.fd",
+                "/usr/share/OVMF/OVMF_VARS.secboot.fd",
+                )),
+        ("ovmf_insecure_code", "ovmf-insecure-code.fd",
+            lambda: first_file(
+                "/usr/share/OVMF/OVMF_CODE_4M.fd",
+                "/usr/share/OVMF/OVMF_CODE.fd",
+                )),
+        ("ovmf_insecure_vars", "ovmf-insecure-vars.fd",
+            lambda: first_file(
+                "/usr/share/OVMF/OVMF_VARS_4M.fd",
+                "/usr/share/OVMF/OVMF_VARS.fd",
+                )),
+    )
+
+    errors = []
+    idir = cliargs.inputs_dir
+    if idir is not None:
+        idir = os.path.normpath(cliargs.inputs_dir)
+
+    for (argname, fname, searcher) in checks:
+        argval = getattr(cliargs, argname)
+        if argval is not None:
+            continue
+        if idir is not None:
+            fpath = path_join(idir, fname)
+            if os.path.exists(fpath):
+                setattr(cliargs, argname, fpath)
+                continue
+        if searcher is not None:
+            fpath = searcher()
+            if fpath is not None:
+                setattr(cliargs, argname, fpath)
+                continue
+        errors.append("did not find value for " + fname)
+
+    # for these paths, we know passwords.
+    known_passwords = {
+        "/usr/share/ovmf/PkKek-1-snakeoil.key": "snakeoil",
+    }
+    # signing_pass is either a file in <idir>/signing.password or password as a string.
+    if cliargs.signing_pass is None:
+        if idir is not None:
+            fpath = path_join(idir, "signing.password")
+            if os.path.exists(fpath):
+                cliargs.signing_pass = read_file(fpath).strip()
+        if cliargs.signing_pass is None:
+            cliargs.signing_pass = known_passwords.get(cliargs.signing_key)
+        if cliargs.signing_pass is None:
+            cliargs.signing_pass = ""
+
+    return errors
+
+
+def _add_run_args(s):
+    runargs = (
+        (("-I", "--inputs-dir"),
+         {"action": "store", "help": "test inputs directory"}),
+        (("-M", "--boot-mode",),
+         {"action": "store", "default": MODE_NVRAM,
+          "help": "The boot mode: %s or %s" % (MODE_UEFI_SHELL, MODE_NVRAM)}),
+        (("-k", "--kernel"),
+         {"action": "store", "help": "linux kernel [<inputs>/kernel]"}),
+        (("-i", "--initrd"),
+         {"action": "store", "help": "linux initramfs [<inputs>/initrd]"}),
+        (("-B", "--sbat"),
+         {"action": "store", "help": "sbat [<inputs>/sbat.csv]"}),
+        (("-S", "--shim"),
+         {"action": "store", "help": "shim.efi [<inputs>/shim.efi]"}),
+        (("-s", "--stubby"),
+         {"action": "store", "help": "stubby [<inputs>/stubby.efi]"}),
+        (("--signing-key",),
+         {"action": "store", "help": "signing key [<inputs>/signing.key]"}),
+        (("--signing-cert",),
+         {"action": "store",
+          "help": "signing certificate [<inputs>/signing.pem]"}),
+        (("--signing-pass",),
+         {"action": "store",
+          "help": "password for the signing key [<inputs>/signing.password]"}),
+        (("--ovmf-secure-code",),
+         {"action": "store", "help": "ovmf-secure-code [<inputs>/ovmf-secure-code.fd]"}),
+        (("--ovmf-insecure-code",),
+         {"action": "store", "help": "ovmf-insecure-code [<inputs>/ovmf-insecure-code.fd]"}),
+        (("--ovmf-secure-vars",),
+         {"action": "store",
+          "help": (
+              "ovmf-vars for secure boot. Must allow execution of code signed"
+              "by provided signing-key [<inputs>/ovmf-secure-vars.fd]")}),
+        (("--ovmf-insecure-vars",),
+         {"action": "store",
+          "help": ("ovmf-vars for insecure boot. [<inputs>/ovmf-insecure-vars.fd]")}),
+    )
+
+    for args, kwargs in runargs:
+        s.add_argument(*args, **kwargs)
+
+
+def decrypt_key(encrypted, secret, output):
+    subp(["openssl", "rsa", "-in", encrypted, "-out",
+          output, "-passin", "stdin"], data=secret)
+
+
+def sign_efi(key, cert, unsigned, signed):
+    subp(["sbsign", "--key=" + key, "--cert=" + cert,
+          "--output=" + signed, unsigned])
+
+
+def smash(output, stubefi, kernel, initrd, sbat, cmdline):
+    cfp, cmdline_f = tempfile.mkstemp(prefix=TMP_PREFIX)
+    os.write(cfp, cmdline.encode("utf-8"))
+    os.close(cfp)
+
+    cmd = [
+        "objcopy",
+        f"--add-section=.cmdline={cmdline_f}",
+        "--change-section-vma=.cmdline=0x30000",
+        f"--add-section=.sbat={sbat}",
+        "--change-section-vma=.sbat=0x50000",
+        "--set-section-alignment=.sbat=512",
+        f"--add-section=.linux={kernel}",
+        "--change-section-vma=.linux=0x1000000",
+        f"--add-section=.initrd={initrd}",
+        "--change-section-vma=.initrd=0x3000000",
+        stubefi, output]
+
+    try:
+        subp(cmd)
+    finally:
+        os.unlink(cmdline_f)
+
+
+def ensure_dir(mdir):
+    if os.path.isdir(mdir):
+        return
+    os.makedirs(mdir)
+
+
+def read_file(path):
+    with open(path, mode="r", encoding="utf-8") as fp:
+        return fp.read()
+
+
+def write_file(path, content):
+    with open(path, mode="w", encoding="utf-8") as fp:
+        fp.write(content)
+
+
+def gen_esp(esp, run_d, mode, kernel, initrd, shim, stubefi, sbat, signing_key, signing_cert,
+            cmdline_builtin, runtime_cli):
+
+    unsigned_kernel = path_join(run_d, "kernel-unsigned.efi")
+    signed_kernel = path_join(run_d, "kernel.efi")
+    startup_nsh = path_join(run_d, "startup.nsh")
+
+    files = [
+        f"{signed_kernel}:kernel.efi",
+        f"{startup_nsh}:startup.nsh",
+    ]
+    if shim:
+        files.append(f"{shim}:shim.efi")
+
+    modes = [MODE_NVRAM, MODE_UEFI_SHELL]
+    if mode not in modes:
+        raise ValueError("Bad mode '%s': expected one of %s" % (mode, ",".join(modes)))
+    if mode == MODE_NVRAM:
+        shutdown_nsh = path_join(run_d, "shutdown.nsh")
+        bootopts = path_join(run_d, "boot.opts")
+        files.extend([f"{shutdown_nsh}:shutdown.nsh", f"{bootopts}:boot.opts"])
+
+        kefi = "kernel.efi"
+        efi = kefi
+        if shim:
+            efi = "shim.efi"
+            runtime_cli = kefi + " " + runtime_cli
+
+        write_file(startup_nsh, STARTUP_NSH_NVRAM.format(efi=efi, args=runtime_cli))
+        write_file(shutdown_nsh, SHUTDOWN_NSH_CONTENT)
+        with codecs.open(bootopts, mode="w", encoding="utf-16le") as fp:
+            fp.write(runtime_cli)
+    elif mode == MODE_UEFI_SHELL:
+        launch_nsh = path_join(run_d, "launch.nsh")
+        files.extend([f"{launch_nsh}:launch.nsh"])
+        write_file(startup_nsh, STARTUP_NSH_UEFI_SHELL)
+        lcontent = "kernel.efi" + f" {runtime_cli}" if runtime_cli else ""
+        if shim:
+            lcontent = "shim.efi " + lcontent
+        write_file(launch_nsh, lcontent + "\n")
+
+    smash(unsigned_kernel, stubefi, kernel, initrd, sbat, cmdline_builtin)
+    sign_efi(signing_key, signing_cert, unsigned_kernel, signed_kernel)
+
+    subp(["gen-esp", "create", esp] + files)
+
+
+def path_join(*args):
+    return os.path.sep.join(args)
+
+
+def get_env_boolean(name, default):
+    if default not in (True, False):
+        raise TypeError(f"Default value for env var {name} was '{default}', not boolean")
+    val = os.environ.get(name)
+    if val is None:
+        return default
+    if val == "true":
+        return True
+    if val == "false":
+        return False
+    raise ValueError(f"environment var {name} had value '{val}'. Expected 'true' or 'false'")
+
+
+class Runner:
+    def __init__(self, cliargs, workdir=None):
+        self.cleanup_workdir = True
+        self.workdir = workdir
+        if self.workdir is None:
+            self.workdir = tempfile.mkdtemp(prefix=TMP_PREFIX)
+
+        self.testinfo = load_test_data(cliargs.testdata)
+        errors = _check_run_args(cliargs)
+        if len(errors) != 0:
+            raise RuntimeError("Errors in cli input:\n  " + "\n  ".join(errors))
+
+        self.results_d = os.path.abspath(cliargs.results)
+        self.boot_mode = cliargs.boot_mode
+        self.kernel = self._to_workd(cliargs.kernel, "kernel")
+        self.initrd = self._to_workd(cliargs.initrd, "initrd")
+        self.stubby = self._to_workd(cliargs.stubby, "stubby.efi")
+        self.shim = self._to_workd(cliargs.shim, "shim.efi")
+        self.sbat = self._to_workd(cliargs.sbat, "sbat.csv")
+        self.ovmf_secure_vars = self._to_workd(
+                cliargs.ovmf_secure_vars, "ovmf-secure-vars.fd")
+        self.ovmf_insecure_vars = self._to_workd(
+                cliargs.ovmf_insecure_vars, "ovmf-insecure-vars.fd")
+        self.ovmf_secure_code = self._to_workd(
+                cliargs.ovmf_secure_code, "ovmf-secure-code.fd")
+        self.ovmf_insecure_code = self._to_workd(
+                cliargs.ovmf_insecure_code, "ovmf-insecure-code.fd")
+
+        self.signing_key_in = cliargs.signing_key
+        self.signing_cert = self._to_workd(cliargs.signing_cert, "signing.pem")
+        self.signing_pass = cliargs.signing_pass
+
+        if self.signing_pass is None:
+            self.signing_key = self._to_workd(self.signing_key_in, "signing.key")
+        else:
+            self.signing_key = path_join(self.workdir, "signing.key")
+            decrypt_key(self.signing_key_in, self.signing_pass, self.signing_key)
+
+        self.signed_shim = path_join(self.workdir, "shim-signed.efi")
+        sign_efi(self.signing_key, self.signing_cert, self.shim, self.signed_shim)
+
+        self.tests = self.testinfo["tests"]
+
+        ensure_dir(self.results_d)
+        test_contents = read_file(cliargs.testdata)
+        write_file(path_join(self.results_d, "tests.yaml"), test_contents)
+
+        # github actions do not support kvm.
+        # https://github.com/actions/runner-images/issues/183
+        self.kvm = get_env_boolean("KVM", True)
+
+    def _to_workd(self, fpath, name):
+        newpath = path_join(self.workdir, name)
+        shutil.copyfile(fpath, newpath)
+        return newpath
+
+    def run_all(self):
+        for testdata in self.tests:
+            self.run(testdata)
+
+    def run_name(self, name):
+        td = None
+        for testdata in self.tests:
+            if testdata.get("name") == name:
+                td = testdata
+                break
+        if td is None:
+            raise KeyError(f"No test named {name}")
+
+        return self.run(td)
+
+    def run(self, testdata):
+        name = testdata["name"]
+        run_d = path_join(self.workdir, name)
+        results_d = path_join(self.results_d, name)
+        ensure_dir(run_d)
+        ensure_dir(results_d)
+        esp = path_join(run_d, "esp.raw")
+
+        qemu_log = path_join(results_d, "qemu.log")
+        slog = path_join(results_d, "serial.log")
+        print(f"Starting {name} in {run_d}\n qemu_log: {qemu_log}\n serial: {slog}.raw")
+
+        gen_esp(
+            esp, run_d=run_d, mode=self.boot_mode,
+            kernel=self.kernel, initrd=self.initrd,
+            shim=self.signed_shim if testdata["shim"] else None,
+            stubefi=self.stubby, sbat=self.sbat,
+            signing_key=self.signing_key, signing_cert=self.signing_cert,
+            cmdline_builtin=testdata["builtin"], runtime_cli=testdata["runtime"])
+
+        ocode_src = self.ovmf_secure_code
+        ovars_src = self.ovmf_secure_vars
+        ovars = path_join(run_d, "ovmf-vars.fd")
+        if not testdata["sb"]:
+            ocode_src = self.ovmf_insecure_code
+            ovars_src = self.ovmf_insecure_vars
+
+        shutil.copyfile(ovars_src, ovars)
+        rel_ovars = os.path.basename(ovars)
+        rel_ocode_src = path_join("..", os.path.basename(ocode_src))
+        rel_esp = os.path.basename(esp)
+
+
+        cmd_base = [
+            "qemu-system-x86_64",
+            "-M", "q35,smm=on" + (",accel=kvm" if self.kvm else ""),
+            "-m", "256",
+            # need to disable s3 for ubuntu ovmf older than 22.04.
+            "-global", "ICH9-LPC.disable_s3=1",
+            "-global", "driver=cfi.pflash01,property=secure,value=on",
+            "-nic", "none",
+            "-drive", f"if=pflash,format=raw,file={rel_ocode_src},readonly=on",
+            # snapshot=on {rel_ovars} so debug with 'boot' will take the full path
+            # rather than shortcutting out the setting of nvram in MODE_NVRAM
+            "-drive", f"if=pflash,format=raw,file={rel_ovars},snapshot=on",
+            "-drive", f"file={rel_esp},id=disk00,if=none,format=raw,index=0,snapshot=on",
+            "-device", "virtio-blk,drive=disk00,serial=esp-image"]
+
+        cmd = cmd_base + [
+             "-serial", f"file:{slog}.raw",
+             "-vnc", "none",
+        ]
+
+        cmd_inter = cmd_base + ["-serial", "mon:stdio"]
+
+        write_file(path_join(run_d, "boot"), "#!/bin/sh\n" + " ".join(cmd_inter) + "\n")
+
+        with open(qemu_log, "wb") as qfp:
+            qfp.write(b"# " + b" ".join([s.encode("utf-8") for s in cmd]) + b"\n")
+            qfp.flush()
+            ret = subp(cmd, capture=False, rcs=None, cwd=run_d,
+                       stderr=subprocess.STDOUT, stdout=qfp, timeout=60)
+            qfp.write(b"\nrc=%d\n" % ret.rc)
+
+        try:
+            if ret.rc != 0:
+                print("qemu output: %s\n" % read_file(qemu_log))
+                raise SubpError(ret)
+        finally:
+            if os.path.exists(slog + ".raw"):
+                with open(slog + ".raw", "rb") as rfp:
+                    with open(slog, "wb") as wfp:
+                        rawlog = rfp.read()
+                        wfp.write(escape_ansi(rawlog))
+                        if not rawlog.endswith(b"\n"):
+                            wfp.write(b"\n")
+
+    def cleanup(self):
+        if self.cleanup_workdir:
+            shutil.rmtree(self.workdir)
+
+
+class TestResult:
+    _unset = object()
+    re_cmdline = re.compile(r"KERNEL COMMAND LINE: (?P<value>[^\n]*)\n")
+    re_rejected = re.compile(r"Custom kernel command line rejected\n")
+    re_warned = re.compile(r"Custom kernel would be rejected in secure mode\n")
+
+    def __init__(self, rdir):
+        self.rdir = rdir
+        self.serial = read_file(path_join(rdir, "serial.log"))
+        self._kcmdline = self._unset
+        self._is_rejected = self._unset
+
+    def serial_raw(self):
+        with open(path_join(self.rdir, "serial.log.raw"), "rb") as fp:
+            return fp.read()
+
+    @functools.lru_cache
+    def kernel_cmdline(self):
+        m = self.re_cmdline.search(self.serial)
+        if m is None:
+            return ""
+        return m.group("value")
+
+    @functools.lru_cache
+    def is_rejected(self):
+        return self.re_rejected.search(self.serial) is not None
+
+    @functools.lru_cache
+    def is_warned(self):
+        return self.re_warned.search(self.serial) is not None
+
+
+class TestError(Exception):
+    pass
+
+
+class Validator:
+    def __init__(self, results_d):
+        self.results_d = results_d
+        self.testinfo = load_test_data(path_join(results_d, "tests.yaml"))
+        self._tests = None
+
+    def tests(self):
+        tests = {}
+        for testdata in self.testinfo["tests"]:
+            tests[testdata["name"]] = testdata
+        return tests
+
+    def _check(self, chkname, tdata, result):
+        CHECKS[chkname](tdata["name"], tdata, result)
+
+    def validate_test(self, tdata):
+        name = tdata["name"]
+        result = TestResult(path_join(self.results_d, name))
+        errors = {}
+        for ast in tdata["assert"]:
+            try:
+                self._check(ast, tdata, result)
+            except TestError as e:
+                errors[ast] = e
+
+        if len(errors) == 0:
+            print(f"{name}: PASS")
+        else:
+            print("%s: FAIL (%s)" % (name, ",".join(errors.keys())))
+
+        return errors
+
+    def validate_all(self):
+        errors = {}
+        for name, tdata in self.tests().items():
+            trdir = path_join(self.results_d, name)
+            if not os.path.isdir(trdir):
+                print(f"no results for test {name}")
+                continue
+            found = self.validate_test(tdata)
+            if found:
+                errors[name] = found
+
+        return errors
+
+
+def validate_results(results_d):
+    vdator = Validator(results_d)
+    errors = vdator.validate_all()
+    if not errors:
+        return 0
+
+    print("== Errors ==")
+    indent = "  "
+    for testname, errdict in errors.items():
+        for assertname, err in errdict.items():
+            print("%s/%s\n %s%s\n" %
+                  (testname, assertname, indent,
+                   ("\n" + indent).join(str(err).splitlines())))
+    return 0
+
+
+def main_run(cliargs):
+    runner = Runner(cliargs)
+    try:
+        tests = runner.tests
+        print("There are %d tests to run" % len(tests))
+        runner.run_all()
+    finally:
+        runner.cleanup()
+
+    errors = validate_results(cliargs.results)
+    if errors:
+        return 1
+    return 0
+
+
+def main_validate(args):
+    validate_results(args.results)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--verbose', '-v', action='count', default=0)
+
+    subcmds = parser.add_subparsers(dest="subcmd")
+    s = subcmds.add_parser("run", help="run the tests")
+    _add_run_args(s)
+    s.add_argument(
+        "--no-validate", action="store_true", default=False,
+        help="Only run tests and collect output. do not validate.")
+    s.add_argument(
+        "-r", "--results", action="store", default="./results",
+        help="Write results output to dir")
+    s.add_argument("testdata", help="The yaml formated test definition file")
+    s.set_defaults(handler=main_run)
+
+    s = subcmds.add_parser("validate", help="validate test results")
+    s.add_argument("results", help="Results dir from 'run'")
+    s.set_defaults(handler=main_validate)
+
+    args = parser.parse_args()
+
+    mydir = os.path.dirname(__file__)
+    os.environ["PATH"] = mydir + ":" + os.environ["PATH"]
+
+    level = (logging.ERROR, logging.INFO, logging.DEBUG)[min(args.verbose, 2)]
+    logging.basicConfig(level=level)
+    if hasattr(args, 'handler'):
+        return args.handler(args)
+    parser.print_help()
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/harness
+++ b/test/harness
@@ -3,7 +3,9 @@ import argparse
 import codecs
 import functools
 import logging
+import multiprocessing
 import os.path
+import queue
 import re
 import shlex
 import shutil
@@ -399,6 +401,9 @@ def _add_run_args(s):
         (("--ovmf-insecure-vars",),
          {"action": "store",
           "help": ("ovmf-vars for insecure boot. [<inputs>/ovmf-insecure-vars.fd]")}),
+        (("--num-threads",),
+          {"action": "store", "type":  int, "default": multiprocessing.cpu_count(),
+           "help": "number of parallel qemu processes to run"}),
     )
 
     for args, kwargs in runargs:
@@ -569,6 +574,7 @@ class Runner:
         # github actions do not support kvm.
         # https://github.com/actions/runner-images/issues/183
         self.kvm = get_env_boolean("KVM", True)
+        self.num_threads = cliargs.num_threads
 
     def _to_workd(self, fpath, name):
         newpath = path_join(self.workdir, name)
@@ -576,8 +582,20 @@ class Runner:
         return newpath
 
     def run_all(self):
+        jobq = queue.Queue()
+        def worker():
+            while True:
+                self.run(jobq.get())
+                jobq.task_done()
+
+        # Turn-on the worker thread.
+        for i in range(self.num_threads):
+            threading.Thread(target=worker, daemon=True).start()
+
         for testdata in self.tests:
-            self.run(testdata)
+            jobq.put(testdata)
+
+        jobq.join()
 
     def run_name(self, name):
         td = None
@@ -774,7 +792,7 @@ def main_run(cliargs):
     runner = Runner(cliargs)
     try:
         tests = runner.tests
-        print("There are %d tests to run" % len(tests))
+        print("There are %d tests to run in %d threads" % (len(tests), cliargs.num_threads))
         runner.run_all()
     finally:
         runner.cleanup()

--- a/test/tests.yaml
+++ b/test/tests.yaml
@@ -1,0 +1,57 @@
+# tests look like:
+#   name: (string) a-unique-name
+#   sb: (bool) run secure-boot ? default is based on name starting with sb-
+#   shim: (bool) use shim ? default based on "sb-shim" or "ib-shim" in name.
+#   runtime: (string) command line arguments to pass to kernel.efi
+#   builtin: (string) the kernel command line to build in.
+#   expected: (string) the expected kernel command line.
+#   assert: (list) list of assertions
+#     - booted-runtime-cli: the kernel booted and had the provided 'runtime'.
+#     - booted-expected-cli: the kernel booted and had the provided 'expected'.
+#     - denied-boot: stubby refused to boot kernel.
+#     - warned-cmdline: stubby warned that secureboot would not allow.
+tests:
+  - name: "sb-shim-allowed"
+    runtime: "root=atomix console=ttyS0"
+    assert:
+      - booted-runtime-cli
+
+  - name: "sb-noshim-allowed"
+    runtime: "root=atomix console=ttyS0"
+    assert:
+      - booted-runtime-cli
+
+  - name: "ib-shim-allowed"
+    runtime: "root=atomix console=ttyS0"
+    assert:
+      - booted-runtime-cli
+
+  - name: "ib-noshim-allowed"
+    runtime: "root=atomix console=ttyS0"
+    assert:
+      - booted-runtime-cli
+
+  - name: "sb-shim-denied"
+    runtime: "root=atomix console=ttyS0 rootkit=yes"
+    assert:
+      - denied-boot
+
+  - name: "ib-shim-denied"
+    runtime: "root=atomix console=ttyS0 rootkit=yes"
+    assert:
+      - warned-cmdline
+      - booted-runtime-cli
+
+  - name: "sb-shim-marker1-allowed"
+    builtin: "root=atomix STUBBY_RT_CLI1 console=ttyS0"
+    runtime: "ro verbose console=tty0"
+    expected: "root=atomix ro verbose console=tty0 console=ttyS0"
+    assert:
+      - booted-expected-cli
+
+  - name: "sb-noshim-marker1-allowed"
+    builtin: "root=atomix STUBBY_RT_CLI1 console=ttyS0"
+    runtime: "ro verbose console=tty0"
+    expected: "root=atomix ro verbose console=tty0 console=ttyS0"
+    assert:
+      - booted-expected-cli


### PR DESCRIPTION
[currently draft, but very close].

There are a few more things I want to do to the boot test:
 * add it to be run by github c-i (.github/workflows/build.yml)
 * fix the 'run' to validate by default 
 * make validate collect all errors rather than exiting on first
 * add a simple 'get the inputs/' script, possibly/probably from a published tarball.
 * rename tests/README-smoser.txt to tests/README.md and put some reasonable content in it.

The top-most commit is the test harness, all the others in here are general stubby fixes that I found as I was writing the test harness (hooray for test!).
