### PR TITLE
Swith root=oci to root=soci

### DIFF
--- a/kcmdline.c
+++ b/kcmdline.c
@@ -10,7 +10,7 @@
 // These are the tokens that are allowed to be passed on EFI cmdline.
 static const CHAR8 allowed[][32] = {
 	"^console=",
-	"^root=oci:",
+	"^root=soci:",
 	"root=atomix",
 	"ro",
 	"quiet",


### PR DESCRIPTION
Require a signed oci layer if we're going to boot from it.

Signed-off-by: Serge Hallyn <serge@hallyn.com>