### PR TITLE
Correct the component_generation number for stubby.puzzelos.

### DIFF
--- a/sbat.csv
+++ b/sbat.csv
@@ -1,3 +1,3 @@
 sbat,1,SBAT Version,sbat,1,https://github.com/rhboot/shim/blob/main/SBAT.md
-stubby.puzzleos,2,PuzzleOS,stubby,1,https://github.com/puzzleos/stubby
+stubby.puzzleos,1,PuzzleOS,stubby,1,https://github.com/puzzleos/stubby
 linux.puzzleos,1,PuzzleOS,linux,1,NOURL


### PR DESCRIPTION
The first 2 components of a sbat entry are:
component_name : the name to be compared
component_generation : the generation number for comparing 
I don't think we have had a sbat containing "1" for stubby.puzzleos, thus there is nothing to compare that "2" to. We should start with "1".

Signed-off-by: Joy Latten <jlatten@cisco.com>