### PR TITLE
feat: adjust CFLAGS and LDFLAGS to produce stubby.efi for aarch64

### DIFF
--- a/make.conf
+++ b/make.conf
@@ -32,14 +32,16 @@ EFI_LDS = ${EFILIB}/elf_${ARCH}_efi.lds
 
 CFLAGS = \
         -Wall -Werror \
-        ${EFIINCS} -fno-stack-protector -fpic -fshort-wchar -mno-red-zone \
+        ${EFIINCS} -fno-stack-protector -fpic -fshort-wchar \
         -DGIT_VERSION=\"$(shell git rev-parse HEAD | cut -c1-12)\"
 ifeq (${ARCH},x86_64)
-CFLAGS += -DEFI_FUNCTION_WRAPPER
+CFLAGS += -DEFI_FUNCTION_WRAPPER -mno-red-zone
 endif
 LDFLAGS = \
         -shared \
         -nostdlib -znocombreloc -T ${EFI_LDS} -Bsymbolic \
         -L ${EFILIB} -L ${LIB} ${EFI_CRT_OBJS}
-
+ifeq (${ARCH},aarch64)
+LDFLAGS += --entry 0x1000
+endif
 # kate: syntax Makefile;


### PR DESCRIPTION
The changes in make.conf produce a stubby.efi file that is properly formed on aarch64 platforms. Previously the efi file was malformed on aarch64 due to some alignment/entrypoint issues.