### PR TITLE
chore: fix warning on github action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install Deps
         run: |
           set -x


### PR DESCRIPTION
Github actions page would show:

   The following actions uses node12 which is deprecated and will
   be forced to run on node16: actions/checkout@v2. For more info:
   https://github.blog/changelog/\
      2023-06-13-github-actions-all-actions-will-run-on-node16