### PR TITLE
upload tests on failure and add timing output

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,7 @@ jobs:
         run: |
           make test
       - name: Boot Test
+        if: '!cancelled()'
         run: |
           fails=""
           for m in nvram efi-shell; do

--- a/test/harness
+++ b/test/harness
@@ -641,6 +641,7 @@ class Runner:
 
         qemu_log = path_join(results_d, "qemu.log")
         serial_log = path_join(results_d, "serial.log")
+        start = time.time()
         print(f"Starting {name} in {run_d}\n qemu_log: {qemu_log}\n serial: {serial_log}.raw")
 
         try:
@@ -657,6 +658,8 @@ class Runner:
         finally:
             write_file(path_join(results_d, "execution-result"), result + "\n")
             rlogfp.close()
+            res = result.split(":")[0]
+            print("Finished %s [%.2fs]: %s" % (name, time.time() - start, res))
 
     def _run(self, testdata, run_d, qemu_log, serial_log, log):
         name = testdata["name"]

--- a/test/harness
+++ b/test/harness
@@ -651,9 +651,10 @@ class Runner:
                 result = "TIMEOUT: " + str(e)
             else:
                 result = "SUBPROCESS: " + str(e)
-            raise
+                raise
         except Exception as e:
             result = "EXCEPTION: " + str(e)
+            # re-raise the unexpected exception
             raise
         finally:
             write_file(path_join(results_d, "execution-result"), result + "\n")


### PR DESCRIPTION
This will
 * upload test results even if the tests failed (where the logs are and such)
 * add timing output to stdout of how long test took and the result of *running* the test (not validating output yet)
 * not show thread stack traces on timeout