### PR TITLE
Run tests on Ubuntu 22.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
I think that we originally used 20.04 due to a bug in 22.04. https://bugs.launchpad.net/bugs/1986692

That is fixed so we should be able to move to 22.04.