### PR TITLE
Add testcase for shim builtin cmdline with no runtime and no marker

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,8 @@ jobs:
           sudo apt-get update --quiet
           sudo apt-get install --quiet --assume-yes --no-install-recommends gnu-efi build-essential
           sudo apt-get install --quiet --assume-yes --no-install-recommends \
-              dosfstools mtools ovmf python3-minimal qemu-system-x86 qemu-utils shim-signed swtpm
+              dosfstools mtools ovmf python3-minimal python3-prettytable \
+              qemu-system-x86 qemu-utils shim-signed swtpm
       - name: Collect Inputs
         run: |
           mkdir ./test-inputs/
@@ -51,7 +52,8 @@ jobs:
             KVM=false ./test/harness run "--boot-mode=$m" \
               --inputs=./test-inputs "--results=./test-results/$m" \
               --sbat=sbat.csv --stubby=stubby.efi \
-              --num-threads=4 --timeout=120 \
+              --num-threads=$(grep -c processor /proc/cpuinfo) \
+              --timeout=120 \
               test/tests.yaml || fails="$fails $m"
           done
 

--- a/kcmdline.c
+++ b/kcmdline.c
@@ -45,7 +45,7 @@ EFI_STATUS check_cmdline(CONST CHAR8 *cmdline, UINTN cmdline_len, CHAR16 *errmsg
 	CHAR8 c = '\0';
 	CHAR8 *buf = NULL;
 	CHAR8 *tokens[MAX_TOKENS];
-	EFI_STATUS status = EFI_SUCCESS;
+	EFI_STATUS status = EFI_SECURITY_VIOLATION;
 	int i;
 	int start = -1;
 	int num_toks = 0;
@@ -56,6 +56,13 @@ EFI_STATUS check_cmdline(CONST CHAR8 *cmdline, UINTN cmdline_len, CHAR16 *errmsg
 	}
 
 	*errmsg = '\0';
+
+	if (cmdline_len == 0) {
+		UnicodeSPrint(errmsg, errmsg_len,
+			L"Empty commandline not allowed: length=0");
+		status = EFI_SECURITY_VIOLATION;
+		goto out;
+	}
 
 	CopyMem(buf, cmdline, cmdline_len);
 	buf[cmdline_len] = '\0';
@@ -94,13 +101,22 @@ EFI_STATUS check_cmdline(CONST CHAR8 *cmdline, UINTN cmdline_len, CHAR16 *errmsg
 		num_toks++;
 	}
 
+	// do not allow an empty command line
+	if (num_toks == 0) {
+		UnicodeSPrint(errmsg, errmsg_len,
+			L"Empty commandline not allowed: no tokens found");
+		status = EFI_SECURITY_VIOLATION;
+		goto out;
+	}
 	for (i=0; i < num_toks; i++) {
 		if (!is_allowed(tokens[i])) {
 			UnicodeSPrint(errmsg, errmsg_len, L"token not allowed: %a", tokens[i]);
 			status = EFI_SECURITY_VIOLATION;
+			goto out;
 		}
 	}
 
+	status = EFI_SUCCESS;
 out:
 
 	if (buf != NULL) {
@@ -167,25 +183,49 @@ EFI_STATUS get_cmdline(
 	part1_len = 0;
 	part2_len = 0;
 
+	/*
+	 * .-------------------------------------------------------------------.
+	 * | case | builtin | runtime | builtin_has_marker | sb  mode | status |
+	 * |------|---------|---------|--------------------|----------|--------|
+	 * |  a   |  True   | False   | False              | insecure | ok     |
+	 * |  b   |  True   | False   | True               | insecure | ok     |
+	 * |  c   |  True   | True    | False              | insecure | ok     |
+	 * |  d   |  True   | True    | True               | insecure | ok     |
+	 * |--------------- ---------------------------------------------------|
+	 * |  e   |  True   | False   | False              |   secure | ok     |
+	 * |  f   |  True   | False   | True               |   secure | ok     |
+	 * |  g   |  True   | True    | False              |   secure | fail   |
+	 * |  h   |  True   | True    | True               |   secure | ok     |
+	 * `-------------------------------------------------------------------'
+	 */
+
 	if (builtin_len != 0) {
+		// cases: a, b, c, d, e, f, g, h
 		p = strstra(builtin, marker);
 		if (p == NULL) {
-			// there was no marker in builtin cmdline
-			if (secure) {
-				if (runtime_len != 0) {
+			// cases: a, c, e, g
+			if (runtime_len != 0) {
+				// cases: c, g
+				if (secure) {
+					// cases: g
 					status = EFI_INVALID_PARAMETER;
 					UnicodeSPrint(errbuf, errbuf_buflen,
 							L"runtime arguments cannot be given to non-empty builtin without marker");
 					goto out;
 				}
-			} else {
-				// insecure and no marker. act as if marker was at end.
-				CopyMem(part1, builtin, builtin_len);
+				// cases: c handled in common path below
+			}
+			// cases: a, c, e
+			CopyMem(part1, builtin, builtin_len);
+			part1_len = builtin_len;
+			// make space for joining builtin and runtime if we have both
+			if (runtime_len != 0) {
 				part1_len = builtin_len + 1;
 				*(part1 + part1_len - 1) = ' ';
 				*(part1 + part1_len) = '\0';
 			}
 		} else {
+			// cases: b, d, f, h
 			// builtin has a marker, check that there is only one.
 			if (strstra(p + marker_len, marker) != NULL) {
 				status = EFI_INVALID_PARAMETER;
@@ -224,17 +264,45 @@ EFI_STATUS get_cmdline(
 		goto out;
 	}
 
-	// Print(L"part1=%a|\npart2=%a|\nruntime=%a|\n", part1, part2, runtime);
-	status = check_cmdline(runtime, runtime_len, errbuf, errbuf_buflen);
+	/* Print(L"builtin=%a len=%d|part1=%a len=%d|\npart2=%a len=%d|\nruntime=%a len=%d|\n",
+		builtin, builtin_len, part1, part1_len, part2, part2_len, runtime, runtime_len); */
+	if (runtime_len > 0) {
+		status = check_cmdline(runtime, runtime_len, errbuf, errbuf_buflen);
 
-	// EFI_SECURITY_VIOLATION is allowed if insecure boot, so continue on.
-	if (EFI_ERROR(status)) {
-		if (status != EFI_SECURITY_VIOLATION || secure) {
-			goto out;
+		// EFI_SECURITY_VIOLATION is allowed if insecure boot, so continue on.
+		if (EFI_ERROR(status)) {
+			if (status != EFI_SECURITY_VIOLATION || secure) {
+				goto out;
+			}
+		}
+	} else {
+		// if we have don't have a runtime component, then we need to check
+		// "builtin" cmdline, but builtin may have the marker, but won't show
+		// up in the two parts that will be joined later
+		if (part1_len > 0) {
+			status = check_cmdline(part1, part1_len, errbuf, errbuf_buflen);
+
+			// EFI_SECURITY_VIOLATION is allowed if insecure boot, so continue on.
+			if (EFI_ERROR(status)) {
+				if (status != EFI_SECURITY_VIOLATION || secure) {
+					goto out;
+				}
+			}
+		}
+
+		if (part2_len > 0) {
+			status = check_cmdline(part2, part2_len, errbuf, errbuf_buflen);
+
+			// EFI_SECURITY_VIOLATION is allowed if insecure boot, so continue on.
+			if (EFI_ERROR(status)) {
+				if (status != EFI_SECURITY_VIOLATION || secure) {
+					goto out;
+				}
+			}
 		}
 	}
 
-	// At this point, part1 and part2 are set so we can just concatenate part1, runtime, part3
+	// At this point, part1 and part2 are set so we can just concatenate part1, runtime, part2
 	UINTN clen = part1_len + runtime_len + part2_len;
 	CHAR8 *cbuf;
 	cbuf = AllocatePool(clen + 1);
@@ -242,13 +310,21 @@ EFI_STATUS get_cmdline(
 		status = EFI_OUT_OF_RESOURCES;
 		goto out;
 	}
+	//Print(L"copying part1 len=%d into cbuf len=%d\n", part1_len, clen);
 	CopyMem(cbuf, part1, part1_len);
-	CopyMem(cbuf+part1_len, runtime, runtime_len);
-	CopyMem(cbuf+part1_len+runtime_len, part2, part2_len);
+
+	if (runtime_len > 0) {
+		CopyMem(cbuf+part1_len, runtime, runtime_len);
+		if (part2_len > 0) {
+			CopyMem(cbuf+part1_len+runtime_len, part2, part2_len);
+		}
+	}
 	cbuf[clen] = '\0';
 	*cmdline = cbuf;
 	*cmdline_len = clen;
 
+	//Print(L"finalized cmdline=%a len=%d\n", cbuf, clen);
+	//FIXME: should we check_cmdline on the final composition?
 out:
 	if (errbuf != NULL && errbuf[0] == '\0') {
 		FreePool(errbuf);

--- a/test-cmdline.c
+++ b/test-cmdline.c
@@ -19,14 +19,14 @@ typedef struct {
 
 TestData tests[] = {
 	{EFI_SUCCESS, "console=ttyS0"},
-	{EFI_SUCCESS, ""},
-	{EFI_SUCCESS, "   "},
 	{EFI_SUCCESS, "quiet"},
 	{EFI_SUCCESS, " root=atomix console=ttyS0"},
 	{EFI_SUCCESS, " root=atomix console=/dev/ttyS0 "},
 	{EFI_SUCCESS, "root=atomix console=/dev/ttyS0"},
 	{EFI_SUCCESS, "crashkernel=256M"},
 	{EFI_SUCCESS, "crashkernel=128M"},
+	{EFI_SECURITY_VIOLATION, ""},
+	{EFI_SECURITY_VIOLATION, "   "},
 	{EFI_SECURITY_VIOLATION, "crashkernel.off=128M"},
 	{EFI_SECURITY_VIOLATION, "root=atomix init=/bin/bash debug"},
 	{EFI_SECURITY_VIOLATION, "init=/bin/bash"},

--- a/test-get-cmdline.c
+++ b/test-get-cmdline.c
@@ -22,13 +22,18 @@ TestData tests[] = {
 		"root=atomix STUBBY_RT_CLI1 more",
 		"console=ttyS0",
 		"root=atomix console=ttyS0 more"},
+	// builtin, not runtime, no token
+	{EFI_SUCCESS, true,
+		"root=atomix console=ttyS0 verbose",
+		"",
+		"root=atomix console=ttyS0 verbose"},
 	// no builtin, use runtime.
 	{EFI_SUCCESS, true,
 		"",
 		"root=atomix verbose",
 		"root=atomix verbose"},
-	// no builtin no runtime means empty.
-	{EFI_SUCCESS, true,
+	// no builtin no runtime means empty, do not boot
+	{EFI_SECURITY_VIOLATION, true,
 		"",
 		"",
 		""},
@@ -62,7 +67,7 @@ TestData tests[] = {
 		"root=atomix STUBBY_RT_CLI1 more2",
 		"console=ttyS0 more1",
 		ResultNotChecked},
-    // marker not a full token
+	// marker not a full token
 	{EFI_INVALID_PARAMETER, false,
 		"root=atomix STUBBY_RT_CLI1=abcd more",
 		"console=ttyS0",
@@ -81,21 +86,21 @@ TestData tests[] = {
 	{EFI_INVALID_PARAMETER, true,
 		"root=atomix STUBBY_RT debug STUBBY_RT_CLI1 ",
 		"console=ttyS0",
-        ResultNotChecked},
+		ResultNotChecked},
 	// namespace for marker found twice in builtin insecure
 	{EFI_INVALID_PARAMETER, false,
 		"root=atomix STUBBY_RT debug STUBBY_RT_CLI1 ",
 		"console=ttyS0",
-        ResultNotChecked},
+		ResultNotChecked},
 	// namespace appears in runtime
 	{EFI_INVALID_PARAMETER, false,
 		"root=atomix debug STUBBY_RT_CLI1",
 		"console=ttyS0 STUBBY_RT",
-        ResultNotChecked},
+		ResultNotChecked},
 };
 
 
-BOOLEAN do_get_cmdline(TestData td) {
+BOOLEAN do_get_cmdline(int testnum, TestData td) {
 	EFI_STATUS status;
 	CHAR16 *errmsg;
 	CHAR8 *found;
@@ -115,7 +120,7 @@ BOOLEAN do_get_cmdline(TestData td) {
 	StatusToString(status_exp, td.expstatus);
 
 	if (status != td.expstatus) {
-		Print(L"expected status '%ls' found '%ls'\n", status_found, status_exp);
+		Print(L"test %d: expected status '%ls' found '%ls'\n", testnum, status_found, status_exp);
 		Print(L"errmsg = %ls\n", errmsg);
 		return false;
 	}
@@ -148,11 +153,11 @@ int main()
 	int passes = 0, fails = 0;
 
 	for (int i=0; i<num; i++) {
-		if (do_get_cmdline(tests[i])) {
+		if (do_get_cmdline(i, tests[i])) {
 			passes++;
 		} else {
 			fails++;
-			Print(L"test %d FAIL\n", i);
+			Print(L"test %d: FAIL\n", i);
 		}
 	}
 

--- a/test-get-cmdline.c
+++ b/test-get-cmdline.c
@@ -28,18 +28,18 @@ TestData tests[] = {
 		"",
 		"root=atomix console=ttyS0 verbose"},
 	// no builtin, use runtime.
-	{EFI_SUCCESS, true,
+	{EFI_INVALID_PARAMETER, true,
 		"",
 		"root=atomix verbose",
-		"root=atomix verbose"},
+		ResultNotChecked},
 	// no builtin no runtime means empty, do not boot
 	{EFI_SECURITY_VIOLATION, true,
 		"",
 		"",
-		""},
-	// insecure, no builtin, bad runtime token allows runtime
+		ResultNotChecked},
+	// insecure, built-in marker, bad runtime arg, inscure boots
 	{EFI_SECURITY_VIOLATION, false,
-		"",
+		"STUBBY_RT_CLI1",
 		"root=atomix verbose rootkit=yes",
 		"root=atomix verbose rootkit=yes"},
 	// all good secure marker at beginning
@@ -77,11 +77,11 @@ TestData tests[] = {
 		"root=atomix",
 		"console=ttyS0",
 		ResultNotChecked},
-	// no marker in insecure - just append.
-	{EFI_SUCCESS, false,
+	// no marker in insecure - runtime args requires marker even insecure
+	{EFI_INVALID_PARAMETER, false,
 		"root=atomix",
 		"console=ttyS0",
-		"root=atomix console=ttyS0"},
+		""},
 	// namespace for marker found twice in builtin secure
 	{EFI_INVALID_PARAMETER, true,
 		"root=atomix STUBBY_RT debug STUBBY_RT_CLI1 ",

--- a/test/harness
+++ b/test/harness
@@ -68,8 +68,8 @@ def booted_expected_cli(_name, tdata, result):
     kcmdline = result.kernel_cmdline()
     if kcmdline != tdata["expected"]:
         raise TestError("\n".join([
-            "kernel command line differed from runtime",
-            " expected: '" + tdata["runtime"] + "'",
+            "kernel command line differed from expected",
+            " expected: '" + tdata["expected"] + "'",
             " found   : '" + kcmdline + "'",
             ]) + "\n")
 
@@ -470,6 +470,7 @@ def gen_esp(esp, run_d, mode, kernel, initrd, shim, stubefi, sbat, signing_key, 
 
     files = [
         f"{signed_kernel}:kernel.efi",
+        f"{signed_kernel}:grubx64.efi",
         f"{startup_nsh}:startup.nsh",
     ]
     if shim:

--- a/test/harness
+++ b/test/harness
@@ -5,6 +5,7 @@ import functools
 import logging
 import multiprocessing
 import os.path
+import pdb
 import queue
 import re
 import shlex
@@ -16,7 +17,10 @@ import threading
 import tempfile
 import textwrap
 import time
+import traceback
 import yaml
+
+import prettytable
 
 
 MODE_NVRAM = 'nvram'
@@ -915,10 +919,17 @@ class TestError(Exception):
 
 
 class Validator:
-    def __init__(self, results_d):
-        self.results_d = results_d
-        self.testinfo = load_test_data(path_join(results_d, "tests.yaml"))
+    def __init__(self, args):
+        self.args = args
+        self.results_d = args.results
+        self.testinfo = load_test_data(path_join(self.results_d, "tests.yaml"))
         self._tests = None
+        self._table = prettytable.PrettyTable()
+        columns = ["Name", "Passed", "Errors"]
+        if self.args.show_config_column:
+            columns.append("Config")
+        self._table.field_names = columns
+        self._table.align = "l"
 
     def tests(self):
         tests = {}
@@ -945,12 +956,7 @@ class Validator:
             except TestError as e:
                 errors[ast] = e
 
-        if len(errors) == 0:
-            print(f"{name}: PASS")
-        else:
-            print("%s: FAIL (%s)" % (name, ",".join(errors.keys())))
-
-        return errors
+        return len(errors) == 0, errors
 
     def validate_all(self):
         errors = {}
@@ -959,16 +965,26 @@ class Validator:
             if not os.path.isdir(trdir):
                 print(f"no results for test {name}")
                 continue
-            found = self.validate_test(tdata)
-            if found:
-                errors[name] = found
+            result, errs = self.validate_test(tdata)
+            if errs:
+                errors[name] = errs
+
+            row = [name, result, ",".join(errs.keys())]
+            if self.args.show_config_column:
+                row.append(tdata)
+            self._table.add_row(row)
 
         return errors
 
+    def print_results(self):
+        print("== Results ==")
+        print(self._table)
 
-def validate_results(results_d):
-    vdator = Validator(results_d)
+
+def validate_results(cliargs):
+    vdator = Validator(cliargs)
     errors = vdator.validate_all()
+    vdator.print_results()
     if not errors:
         return 0
 
@@ -991,14 +1007,14 @@ def main_run(cliargs):
     finally:
         runner.cleanup()
 
-    errors = validate_results(cliargs.results)
+    errors = validate_results(cliargs)
     if errors:
         return 1
     return 0
 
 
 def main_validate(args):
-    validate_results(args.results)
+    validate_results(args)
 
 
 def main():
@@ -1014,6 +1030,9 @@ def main():
     s.add_argument(
         "-r", "--results", action="store", default="./results",
         help="Write results output to dir")
+    s.add_argument(
+        "-C", "--show-config-column", action="store_true", default=False,
+        help="Display the 'Config' column in validate results")
     s.add_argument("testdata", help="The yaml formated test definition file")
     s.set_defaults(handler=main_run)
 
@@ -1035,4 +1054,11 @@ def main():
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    ret = 0
+    try:
+        ret = main()
+    except Exception:
+        traceback.print_exc()
+        pdb.post_mortem()
+        ret = 1
+    sys.exit(ret)

--- a/test/tests.yaml
+++ b/test/tests.yaml
@@ -10,13 +10,26 @@
 #     - booted-expected-cli: the kernel booted and had the provided 'expected'.
 #     - denied-boot: stubby refused to boot kernel.
 #     - warned-cmdline: stubby warned that secureboot would not allow.
+#
+# notes:
+#   sb-shim -> secureboot=true  shim=yes
+#   ib-shim -> secureboot=false shim=yes
+#   no-shim -> secureboot=false shim=no
+
 tests:
-  - name: "sb-shim-allowed-rt-only"
+  - name: "sb-shim-denied-rt-only"
     builtin: ""
     runtime: "root=atomix console=ttyS0"
-    expected: "root=atomix console=ttyS0"
+    expected: ""
     assert:
-        - booted-runtime-cli
+        - denied-boot
+
+  - name: "ib-shim-denied-rt-only"
+    builtin: ""
+    runtime: "root=atomix console=ttyS0"
+    expected: ""
+    assert:
+        - denied-boot
 
   - name: "sb-shim-allowed-built-in-no-rt-no-marker"
     builtin: "root=atomix console=ttyS0"
@@ -25,28 +38,94 @@ tests:
     assert:
       - booted-expected-cli
 
-  - name: "sb-noshim-allowed"
-    runtime: "root=atomix console=ttyS0"
+  - name: "ib-shim-allowed-built-in-no-rt-no-marker"
+    builtin: "root=atomix console=ttyS0"
+    runtime: ""
+    expected: "root=atomix console=ttyS0"
     assert:
-      - booted-runtime-cli
+      - booted-expected-cli
 
-  - name: "ib-shim-allowed"
-    runtime: "root=atomix console=ttyS0"
-    assert:
-      - booted-runtime-cli
-
-  - name: "ib-noshim-allowed"
-    runtime: "root=atomix console=ttyS0"
-    assert:
-      - booted-runtime-cli
-
-  - name: "sb-shim-denied"
-    runtime: "root=atomix console=ttyS0 rootkit=yes"
+  - name: "sb-shim-denied-built-in-rt-no-marker"
+    builtin: "root=atomix console=ttyS0"
+    runtime: "crashkernel=256M"
+    expected: ""
     assert:
       - denied-boot
 
-  - name: "ib-shim-denied"
+  - name: "ib-shim-denied-built-in-rt-no-marker"
+    builtin: "root=atomix console=ttyS0"
+    runtime: "crashkernel=256M"
+    expected: ""
+    assert:
+      - denied-boot
+
+  - name: "sb-shim-denied-empty-built-in-rt"
+    builtin: ""
+    runtime: "root=atomix console=ttyS0"
+    expected: ""
+    assert:
+      - denied-boot
+
+  - name: "ib-shim-denied-empty-built-in-rt"
+    builtin: ""
+    runtime: "root=atomix console=ttyS0"
+    expected: ""
+    assert:
+      - denied-boot
+
+  - name: "sb-shim-allowed-built-in-rt-has-marker"
+    builtin: "STUBBY_RT_CLI1"
+    runtime: "root=atomix verbose console=ttyS0"
+    expected: ""
+    assert:
+      - booted-runtime-cli
+
+  - name: "ib-shim-allowed-built-in-rt-has-marker"
+    builtin: "STUBBY_RT_CLI1"
+    runtime: "root=atomix verbose console=ttyS0"
+    expected: ""
+    assert:
+      - booted-runtime-cli
+
+  - name: "sb-noshim-denied-no-marker"
+    builtin: ""
+    runtime: "root=atomix console=ttyS0"
+    expected: ""
+    assert:
+      - denied-boot
+
+  - name: "ib-noshim-denied-no-marker"
+    builtin: ""
+    runtime: "root=atomix console=ttyS0"
+    expected: ""
+    assert:
+      - denied-boot
+
+  - name: "sb-noshim-allowed-with-marker"
+    builtin: "STUBBY_RT_CLI1"
+    runtime: "root=atomix console=ttyS0"
+    expected: "root=atomix console=ttyS0"
+    assert:
+      - booted-expected-cli
+
+  - name: "ib-noshim-denied-with-marker"
+    builtin: ""
+    runtime: "root=atomix console=ttyS0"
+    expected: ""
+    assert:
+      - denied-boot
+
+  - name: "sb-shim-denied-builtin-marker-bad-args"
+    builtin: "STUBBY_RT_CLI1"
     runtime: "root=atomix console=ttyS0 rootkit=yes"
+    expected: ""
+    assert:
+      - denied-boot
+
+  - name: "ib-shim-warned-builtin-marker-bad-args"
+    builtin: "STUBBY_RT_CLI1"
+    runtime: "root=atomix console=ttyS0 rootkit=yes"
+    expected: ""
     assert:
       - warned-cmdline
       - booted-runtime-cli

--- a/test/tests.yaml
+++ b/test/tests.yaml
@@ -11,10 +11,19 @@
 #     - denied-boot: stubby refused to boot kernel.
 #     - warned-cmdline: stubby warned that secureboot would not allow.
 tests:
-  - name: "sb-shim-allowed"
+  - name: "sb-shim-allowed-rt-only"
+    builtin: ""
     runtime: "root=atomix console=ttyS0"
+    expected: "root=atomix console=ttyS0"
     assert:
-      - booted-runtime-cli
+        - booted-runtime-cli
+
+  - name: "sb-shim-allowed-built-in-no-rt-no-marker"
+    builtin: "root=atomix console=ttyS0"
+    runtime: ""
+    expected: "root=atomix console=ttyS0"
+    assert:
+      - booted-expected-cli
 
   - name: "sb-noshim-allowed"
     runtime: "root=atomix console=ttyS0"


### PR DESCRIPTION
Test out the path where kernel.efi has a built-in value, without a marker, and no runtime args are supplied.