### PR TITLE
Generate git version and include that in source output

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,8 +22,12 @@ jobs:
           sudo apt-get update --quiet
           sudo apt-get install --quiet --assume-yes --no-install-recommends gnu-efi build-essential
           sudo apt-get install --quiet --assume-yes --no-install-recommends \
-              dosfstools mtools ovmf python3-minimal python3-prettytable \
+              coreutils dosfstools git mtools python3-minimal python3-prettytable \
               qemu-system-x86 qemu-utils shim-signed swtpm
+          # use a specific version of OVMF which does not have uefi-shell
+          # disabled.  See: https://bugs.launchpad.net/ubuntu/+source/edk2/+bug/2040137
+          sudo apt-get install --quiet --assume-yes --no-install-recommends \
+              ovmf=0~20191122.bd85bf54-2ubuntu3
       - name: Collect Inputs
         run: |
           mkdir ./test-inputs/
@@ -48,9 +52,11 @@ jobs:
       - name: Boot Test
         run: |
           fails=""
+          set -x
           for m in nvram efi-shell; do
             echo "== $m =="
-            KVM=false ./test/harness run "--boot-mode=$m" \
+            KVM=false ./test/harness \
+              run "--boot-mode=$m" \
               --inputs=./test-inputs "--results=./test-results/$m" \
               --sbat=sbat.csv --stubby=stubby.efi \
               --num-threads=$(grep -c processor /proc/cpuinfo) \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,7 @@ jobs:
           ./test/get-krd ./test-inputs
       - name: Build
         run: |
+          make show-version
           make build
       - name: Upload Build
         uses: actions/upload-artifact@v3

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.so
 *.efi
 test-cmdline
+git-version

--- a/Makefile
+++ b/Makefile
@@ -59,8 +59,13 @@ LINUX_TEST_CFLAGS := -DLINUX_TEST $(filter-out -fshort-wchar,$(CFLAGS))
 test-%: test-%-lt.o $(TEST_OBJS)
 	$(CC) $(LINUX_TEST_CFLAGS) -o $@ $^
 
+.PHONY: show-version
+show-version:
+	@echo $(VERSION)
+
 .PHONY: clean
 tarball:
+	@[ -s git-version ] || echo $(VERSION)
 	./tools/make-tarball
 
 .PHONY: clean

--- a/make.conf
+++ b/make.conf
@@ -18,6 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
+SHELL=/bin/bash
 
 ARCH ?= $(shell uname -m | sed s,i[3456789]86,ia32,)
 
@@ -30,10 +31,17 @@ EFILIB ?= ${LIB}
 EFI_CRT_OBJS = ${EFILIB}/crt0-efi-${ARCH}.o
 EFI_LDS = ${EFILIB}/elf_${ARCH}_efi.lds
 
+GIT_VERSION = $(shell git describe --always --dirty --match="v[0-9]*" 2>/dev/null)
+ifeq ($(GIT_VERSION),)
+VERSION = $(shell cat git-version 2>/dev/null)
+else
+VERSION = $(shell echo $(GIT_VERSION) | tee git-version)
+endif
+
 CFLAGS = \
         -Wall -Werror \
         ${EFIINCS} -fno-stack-protector -fpic -fshort-wchar \
-        -DGIT_VERSION=\"$(shell git rev-parse HEAD | cut -c1-12)\"
+        -DVERSION=\"$(VERSION)\"
 ifeq (${ARCH},x86_64)
 CFLAGS += -DEFI_FUNCTION_WRAPPER -mno-red-zone
 endif

--- a/stub.c
+++ b/stub.c
@@ -36,7 +36,7 @@
 
 /* magic string to find in the binary image */
 static const char __attribute__((used)) magic[] =
-	"#### LoaderInfo: stubby " GIT_VERSION " ####";
+	"#### LoaderInfo: stubby " VERSION " ####";
 
 BOOLEAN use_shell_cmdline(UINTN len)
 {
@@ -199,7 +199,7 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table)
 	/* add StubInfo */
 	if (efivar_get_raw(&loader_guid,
 			   L"StubInfo", NULL, NULL) != EFI_SUCCESS)
-		efivar_set(L"StubInfo", L"stubby " GIT_VERSION, FALSE);
+		efivar_set(L"StubInfo", L"stubby " VERSION, FALSE);
 
 	err = linux_exec(image, cmdline, cmdline_len,
 			 (UINTN)loaded_image->ImageBase + addrs[1],

--- a/test/collect-firmwares
+++ b/test/collect-firmwares
@@ -33,13 +33,19 @@ set --
 [ -d "$outd" ] || mkdir "$outd" ||
     fail "failed to make output dir"
 
+ovmf_version=""
+# https://bugs.launchpad.net/ubuntu/+source/edk2/+bug/2040137
+if [ "$(lsb_release -sc)" = "focal" ]; then
+    ovmf_version="=0~20191122.bd85bf54-2ubuntu3"
+fi
+
 if [ "$install" = "true" ]; then
     [ "$(id -u)" = "0" ] ||
         fail "must be root for install (try sudo or --no-install)"
     apt-get update --quiet || fail "apt-get update failed."
     apt-get install --quiet \
         --assume-yes --no-install-recommends \
-        ovmf shim-signed ||
+        ovmf${ovmfversion} shim-signed ||
         fail "failed install deps"
 else
     echo "skipping install"
@@ -101,6 +107,7 @@ for line in "$@"; do
         *)
             cp "$src" "$outd/$target" || fail "failed copy $src -> $target"
             echo "copied $src to $target"
+            md5sum $src $outd/$target
         ;;
     esac
 done

--- a/test/harness
+++ b/test/harness
@@ -655,6 +655,7 @@ class Runner:
             self.workdir = os.path.abspath(workdir)
             ensure_dir(self.workdir)
 
+        self.verbose = cliargs.verbose
         self.timeout = cliargs.timeout
         self.testinfo = load_test_data(cliargs.testdata)
         errors = _check_run_args(cliargs)
@@ -772,6 +773,11 @@ class Runner:
             rlogfp.close()
             res = result.split(":")[0]
             print("Finished %s [%.2fs]: %s" % (name, time.time() - start, res))
+            if self.verbose > 0:
+                print("\n --- TEST [%s] serial.log ---\n" % name)
+                with open(serial_log) as fh:
+                    print("%s\n" % "".join(fh.readlines()))
+                print(" --- TEST [%s] end log ---\n" % name)
 
     def _run(self, testdata, run_d, results_d, qemu_log, serial_log, log):
         esp = path_join(run_d, "esp.raw")

--- a/tools/make-tarball
+++ b/tools/make-tarball
@@ -51,7 +51,7 @@ fi
 version=${version#v}
 archive_base="stubby-$version"
 if [ -z "$output" ]; then
-    output="$archive_base.tar.gz"
+    output="$archive_base.tar"
 fi
 
 # when building an archiving from HEAD, ensure that there aren't any
@@ -66,6 +66,15 @@ if [ "$rev" = HEAD ] && ! git diff-index --quiet HEAD --; then
     fi
 fi
 
-git archive --format=tgz "--output=$output" "--prefix=$archive_base/" "$rev" ||
+# generate tar format to enable version insertion
+git archive --format=tar "--output=$output" "--prefix=$archive_base/" "$rev" ||
     fail "git archive failed"
-echo "$output"
+
+# insert the git-version value
+echo "$version" > git-version
+tar --append -f ${output} --transform "s,^,$archive_base/," git-version ||
+    fail "appending git-version to archive failed"
+gzip ${output} ||
+    fail "failed to compress archive"
+
+echo "${output}.gz"


### PR DESCRIPTION
The current GIT_VERSION value only works if you build from a git repo.  Once we release on github, the tarballs that one can download are not git repos and the git command to describe the version fail.

Generate the git version value and write to a file.  In source tarball builds, the value will come from the file rather than git.

- Add 'show-version' as makefile target
- Add 'show-version' to github workflow
- Adjust make-tarball tool to insert the git-version file

Fixes: #45 