### PR TITLE
fix: Use objcopy --output-target to avoid setting input-target

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,8 +26,12 @@ jobs:
               qemu-system-x86 qemu-utils shim-signed swtpm
           # use a specific version of OVMF which does not have uefi-shell
           # disabled.  See: https://bugs.launchpad.net/ubuntu/+source/edk2/+bug/2040137
-          sudo apt-get install --quiet --assume-yes --no-install-recommends \
-              ovmf=0~20191122.bd85bf54-2ubuntu3
+          # this version is from Jammy so it has 2M and 4M variants but does not
+          # restrict access to uefi-shell when secureboot is enabled
+          ovmf_url="https://launchpadlibrarian.net/588079729/ovmf_2022.02-1_all.deb"
+          ovmf_deb=$(basename $ovmf_url)
+          wget ${ovmf_url}
+          sudo dpkg --install ${ovmf_deb}
       - name: Collect Inputs
         run: |
           mkdir ./test-inputs/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,10 +7,10 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Deps
         run: |
           set -x
@@ -38,7 +38,7 @@ jobs:
           make show-version
           make build
       - name: Upload Build
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error
           name: stubby
@@ -70,7 +70,7 @@ jobs:
 
       - name: Upload Test Results
         if: '!cancelled()'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error
           name: test-data

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ stubby.so: ${STUBBY_OBJS}
 %.efi: %.so
 	objcopy -j .text -j .sdata -j .data -j .dynamic \
 		-j .dynsym  -j .rel -j .rela -j .reloc \
-		--target=efi-app-${ARCH} $^ $@
+		--output-target=efi-app-${ARCH} $^ $@
 
 
 .PHONY: test

--- a/test/collect-firmwares
+++ b/test/collect-firmwares
@@ -33,11 +33,10 @@ set --
 [ -d "$outd" ] || mkdir "$outd" ||
     fail "failed to make output dir"
 
-ovmf_version=""
 # https://bugs.launchpad.net/ubuntu/+source/edk2/+bug/2040137
-if [ "$(lsb_release -sc)" = "focal" ]; then
-    ovmf_version="=0~20191122.bd85bf54-2ubuntu3"
-fi
+# use this common version for all:
+ovmf_url="https://launchpadlibrarian.net/588079729/ovmf_2022.02-1_all.deb"
+ovmf_deb=$(basename "$ovmf_url")
 
 if [ "$install" = "true" ]; then
     [ "$(id -u)" = "0" ] ||
@@ -45,8 +44,10 @@ if [ "$install" = "true" ]; then
     apt-get update --quiet || fail "apt-get update failed."
     apt-get install --quiet \
         --assume-yes --no-install-recommends \
-        ovmf${ovmfversion} shim-signed ||
+        shim-signed ||
         fail "failed install deps"
+    wget "${ovmf_url}" -O "${ovmf_deb}" || fail "failed to download $ovmf_url"
+    dpkg --install "${ovmf_deb}" || fail "failed to install ${ovmf_deb}"
 else
     echo "skipping install"
 fi
@@ -61,7 +62,7 @@ set -- "$@" \
 
 bd=/usr/share/OVMF
 case "$REL" in
-    jammy)
+    focal|jammy|noble)
         set -- "$@" \
             "$bd/OVMF_VARS_4M.fd" \
             "$bd/OVMF_CODE_4M.secboot.fd" \
@@ -70,16 +71,6 @@ case "$REL" in
             "ovmf-insecure-vars.fd|link:OVMF_VARS_4M.fd" \
             "ovmf-secure-code.fd|link:OVMF_CODE_4M.secboot.fd" \
             "ovmf-secure-vars.fd|link:OVMF_VARS_4M.snakeoil.fd"
-        ;;
-    focal)
-        set -- "$@" \
-            "$bd/OVMF_VARS.fd" \
-            "$bd/OVMF_CODE.secboot.fd" \
-            "$bd/OVMF_VARS.snakeoil.fd" \
-            "ovmf-insecure-code.fd|link:OVMF_CODE.secboot.fd" \
-            "ovmf-insecure-vars.fd|link:OVMF_VARS.fd" \
-            "ovmf-secure-code.fd|link:OVMF_CODE.secboot.fd" \
-            "ovmf-secure-vars.fd|link:OVMF_VARS.snakeoil.fd"
         ;;
     *) fail "unknown release $REL";;
 esac
@@ -107,7 +98,7 @@ for line in "$@"; do
         *)
             cp "$src" "$outd/$target" || fail "failed copy $src -> $target"
             echo "copied $src to $target"
-            md5sum $src $outd/$target
+            md5sum $src "$outd/$target"
         ;;
     esac
 done


### PR DESCRIPTION
Newer binutils 2.45.50+ "fixes" use of --target which cli documents as setting both input and output targets.  However, up until versions in 25.10 (Ubuntu Questing) this flag didn't fail like it does now where it errors out with:

objcopy: file format not recognized.

Some details in [LP:#2134326](https://bugs.launchpad.net/ubuntu/+source/binutils/+bug/2134326) now closed as invalid after testing out use of --output-target.